### PR TITLE
Topic Wildcard Bug Fix

### DIFF
--- a/lib/helpers/routeMatcher.js
+++ b/lib/helpers/routeMatcher.js
@@ -2,8 +2,8 @@
 
 const regexPatternLookup = {};
 const regexTokenLookup = {};
-regexTokenLookup['*'] = '[\\d\\w*#]*';
-regexTokenLookup['#'] = '[\\d\\w.*#]*';
+regexTokenLookup['*'] = '[\\d\\w-_*#]*';
+regexTokenLookup['#'] = '[\\d\\w-_.*#]*';
 
 const routeMatcher = (pattern, match) => {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -965,7 +965,6 @@ class BunnyBus extends EventEmitter{
         ], (err) => {
 
             if (!err) {
-                console.log('CONNECTION CLOSED');
                 $.connection = null;
             }
 

--- a/test/node6/helpers.js
+++ b/test/node6/helpers.js
@@ -481,6 +481,21 @@ describe('helpers', () => {
             });
         });
 
+        describe('when binding pattern is abc.xyz-rpq_mno', () => {
+
+            const pattern = 'abc.xyz-rpq_mno';
+
+            it('should match for abc.xyz-rpq_mno', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'abc.xyz-rpq_mno')).to.be.true();
+            });
+
+            it('should not match for xyz.abc-rpq_mno', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'xyz.abc-rpq_mno')).to.be.false();
+            });
+        });
+
         describe('when binding pattern is a.*', () => {
 
             const pattern = 'a.*';
@@ -560,9 +575,14 @@ describe('helpers', () => {
                 expect(Helpers.routeMatcher(pattern, 'a..b')).to.be.true();
             });
 
-            it('should match for a.b', () => {
+            it('should not match for a.b', () => {
 
                 expect(Helpers.routeMatcher(pattern, 'a.b')).to.be.false();
+            });
+
+            it('should not match for a.n.d.b', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.n.d.b')).to.be.false();
             });
         });
 
@@ -595,9 +615,44 @@ describe('helpers', () => {
                 expect(Helpers.routeMatcher(pattern, 'hello.world.b')).to.be.false();
             });
 
-            it('should match for a.hello.world', () => {
+            it('should not match for a.hello.world', () => {
 
                 expect(Helpers.routeMatcher(pattern, 'a.hello.world')).to.be.false();
+            });
+        });
+
+        describe('when binding pattern is a.#.b-_c', () => {
+
+            const pattern = 'a.#.b-_c';
+
+            it('should match for a.hello.world.b-_c', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello.world.b-_c')).to.be.true();
+            });
+
+            it('should match for a.h-e-l-l-o.w-o-r-l-d.b-_c', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.h-e-l-l-o.w-o-r-l-d.b-_c')).to.be.true();
+            });
+
+            it('should match for a.h_e_l_l_o.w_o_r_l_d.b-_c', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.h-e-l-l-o.w-o-r-l-d.b-_c')).to.be.true();
+            });
+
+            it('should match for a.h-e_l-l_o.w_o-r_l-d.b-_c', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.h-e-l-l-o.w-o-r-l-d.b-_c')).to.be.true();
+            });
+
+            it('should not match for b.h-e_l-l_o.w_o-r_l-d.b-_c', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'b.h-e_l-l_o.w_o-r_l-d.b-_c')).to.be.false();
+            });
+
+            it('should not match for a.h-e_l-l_o.w_o-r_l-d.b', () => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.h-e_l-l_o.w_o-r_l-d.b')).to.be.false();
             });
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
RabbitMQ supports wildcard route matching through the `#` and `*` characters in the topic key that is found [here](https://www.rabbitmq.com/tutorials/tutorial-four-python.html).  BunnyBus should provide the same level of functionality when interpreting incoming route keys for topic name patterns subscribed for queues with the associated function handles.  This PR fixes wild card interpretation for white space character specifically the subset of `-` and `_`.   The `RouteMatcher` helper will now evaluate the following correctly.

* Pattern `a.#.b` now matches for:
  * `a.t.b`
  * `a.t-v.b`
  * `a.t_v.b`

Previously, messages were being dropped when the above patterns were not matching.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Topic handling needs to be symmetric with RabbitMQ exchange -> queue binding rule capabilities.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.