### PR TITLE
Test Cleanup with PromsifyWrap

### DIFF
--- a/test/node6/autorecovery.js
+++ b/test/node6/autorecovery.js
@@ -2,7 +2,7 @@
 
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
-const { Promisify, PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = (exports.lab = Lab.script());
 const before = lab.before;
@@ -32,7 +32,7 @@ describe('automatic recovery cases', () => {
 
         it('should correctly recover consumers', { timeout: 5000 }, async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.RECOVERED_EVENT, () => {
 

--- a/test/node6/helpers.js
+++ b/test/node6/helpers.js
@@ -7,7 +7,7 @@ const Q = require('q');
 const Bluebird = require('bluebird');
 const Assertions = require('./assertions');
 const Helpers = require('../../lib/helpers');
-const { PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 const EventLogger = require('../../lib/loggers').EventLogger;
 
 const lab = exports.lab = Lab.script();
@@ -43,7 +43,7 @@ describe('helpers', () => {
 
         it('should create only unique tokens', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const iterations = 1000;
 
@@ -143,7 +143,7 @@ describe('helpers', () => {
 
         it('should convert a string to a Buffer', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const data = 'hello';
 
@@ -153,7 +153,7 @@ describe('helpers', () => {
 
         it('should convert an object to a Buffer', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const data = {
                     a : 'root1',
@@ -170,7 +170,7 @@ describe('helpers', () => {
 
         it('should convert an array to a Buffer', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const data = ['a', 'b', 1, 2];
 
@@ -180,7 +180,7 @@ describe('helpers', () => {
 
         it('should not alter a Buffer input', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const data = Buffer.from('hello');
 
@@ -355,7 +355,7 @@ describe('helpers', () => {
 
         it('should return true when validating EventLogger', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertValidateLoggerContract(new EventLogger(), true, done);
             });
@@ -363,7 +363,7 @@ describe('helpers', () => {
 
         it('should return true when validating custom logger object', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'warn', 'error', 'fatal'), true, done);
             });
@@ -371,7 +371,7 @@ describe('helpers', () => {
 
         it('should return false when validating custom logger missing debug', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertValidateLoggerContract(FakeLoggerFactory('info', 'warn', 'error', 'fatal'), false, done);
             });
@@ -379,7 +379,7 @@ describe('helpers', () => {
 
         it('should return false when validating custom logger missing info', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'warn', 'error', 'fatal'), false, done);
             });
@@ -387,7 +387,7 @@ describe('helpers', () => {
 
         it('should return false when validating custom logger missing warn', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'error', 'fatal'), false, done);
             });
@@ -395,7 +395,7 @@ describe('helpers', () => {
 
         it('should return false when validating custom logger missing error', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'warn', 'fatal'), false, done);
             });
@@ -403,7 +403,7 @@ describe('helpers', () => {
 
         it('should return false when validating custom logger missing fatal', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'warn', 'error'), false, done);
             });

--- a/test/node6/integration-callback.js
+++ b/test/node6/integration-callback.js
@@ -5,7 +5,7 @@ const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const Exceptions = require('../../lib/exceptions');
 const Assertions = require('./assertions');
-const { Promisify, PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const before = lab.before;
@@ -45,7 +45,7 @@ describe('positive integration tests with no configuration - Callback api', () =
 
         it('should create connection and channel', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance._autoConnectChannel((err) => {
 
@@ -100,7 +100,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should close an opened connection', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._createConnection,
@@ -125,7 +125,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         beforeEach(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._closeChannel.bind(instance),
@@ -136,7 +136,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should create channel with default values', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance._createChannel((err) => {
 
@@ -149,7 +149,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should close an opened channel', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._createChannel,
@@ -165,7 +165,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should close both connection and channel when closing a connection', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._createChannel,
@@ -190,7 +190,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should create connection and channel', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance._autoConnectChannel((err) => {
 
@@ -204,7 +204,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should create connection and channel properly with no race condition', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.parallel([
                     instance._autoConnectChannel,
@@ -236,7 +236,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should recreate connection when connection error occurs', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.connection.emit('error');
 
@@ -251,7 +251,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should recreate connection when channel error occurs', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.channel.emit('error');
 
@@ -276,7 +276,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should create queue with name `test-queue-1`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.createQueue(queueName, (err, result) => {
 
@@ -290,7 +290,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should check queue with name `test-queue-1`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.checkQueue(queueName, (err, result) => {
 
@@ -304,7 +304,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should delete queue with name `test-queue-1`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.deleteQueue(queueName, (err, result) => {
 
@@ -322,7 +322,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -341,7 +341,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should create exchange with name `test-exchange-1`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.createExchange(exchangeName, 'topic', (err, result) => {
 
@@ -353,7 +353,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should check exchange with name `test-exchange-1`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.checkExchange(exchangeName, (err, result) => {
 
@@ -365,7 +365,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should delete exchange with name `test-exchange-1`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.deleteExchange(exchangeName, (err, result) => {
 
@@ -377,7 +377,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should recover from a non existent exchange', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.RECOVERED_EVENT, done);
 
@@ -404,7 +404,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should send message', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertSend(instance, message, queueName, null, null, null, null, done);
             });
@@ -412,7 +412,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should send message when miscellaneous amqplib options are included', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const amqpOptions = {
                     expiration: '1000',
@@ -440,7 +440,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should proxy `source` when supplied', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertSend(instance, message, queueName, null, 'someModule', null, null, done);
             });
@@ -448,7 +448,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should proxy `transactionId` when supplied', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertSend(instance, message, queueName, 'someTransactionId', null, null, null, done);
             });
@@ -456,7 +456,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should proxy `routeKey` when supplied', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertSend(instance, message, queueName, null, null, 'event1', null, done);
             });
@@ -464,7 +464,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should proxy `routeKey` when supplied', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertSend(instance, messageWithEvent, queueName, null, null, null, null, done);
             });
@@ -488,7 +488,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should retrieve all message without meta flag', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertGetAll(instance, message, queueName, false, 10, done);
             });
@@ -496,7 +496,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should retrieve all message with meta flag', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertGetAll(instance, message, queueName, true, 10, done);
             });
@@ -511,7 +511,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -533,7 +533,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -545,7 +545,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `a`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'a', null, null, true, null, done);
             });
@@ -553,7 +553,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `a`  when miscellaneous amqplib options are included', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const amqpOptions = {
                     expiration: '1000',
@@ -580,7 +580,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `a.b`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'a.b', null, null, true, null, done);
             });
@@ -588,7 +588,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `b`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'b', null, null, true, null, done);
             });
@@ -596,7 +596,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `b.b`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'b.b', null, null, true, null, done);
             });
@@ -604,7 +604,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `z.a`', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'z.a', null, null, true, null, done);
             });
@@ -612,7 +612,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `z` but not route to queue', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'z', null, null, false, null, done);
             });
@@ -620,7 +620,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should proxy `source` when supplied', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'a', null, 'someModule', true, null, done);
             });
@@ -628,7 +628,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should proxy `transactionId` when supplied', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertPublish(instance, message, queueName, 'a', 'someTransactionId', null, true, null, done);
             });
@@ -636,7 +636,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should publish for route `a` when route key is provided in the message', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const messageWithRoute = Object.assign({}, message, { event : 'a' });
 
@@ -657,7 +657,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -675,7 +675,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -688,7 +688,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Object) from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[messageObject.event] = (consumedMessage, ack) => {
@@ -712,7 +712,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Object) and meta from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[messageObject.event] = (consumedMessage, meta, ack) => {
@@ -738,7 +738,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (String) from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[publishOptions.routeKey] = (consumedMessage, ack) => {
@@ -762,7 +762,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (String) and meta from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[publishOptions.routeKey] = (consumedMessage, meta, ack) => {
@@ -788,7 +788,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Buffer) from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[publishOptions.routeKey] = (consumedMessage, ack) => {
@@ -812,7 +812,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Buffer) and meta from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[publishOptions.routeKey] = (consumedMessage, meta, ack) => {
@@ -838,7 +838,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Object) from queue and reject off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[messageObject.event] = (consumedMessage, ack, reject) => {
@@ -874,7 +874,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Buffer) from queue and reject off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[publishOptions.routeKey] = (consumedMessage, ack, reject) => {
@@ -910,7 +910,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Object) from queue and requeue off on maxRetryCount', { timeout : 0 }, async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 const maxRetryCount = 3;
@@ -944,7 +944,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Buffer) from queue and requeue off on maxRetryCount', { timeout : 0 }, async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 const maxRetryCount = 3;
@@ -978,7 +978,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should reject message without bunnyBus header property', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 const config = instance.config;
@@ -1018,7 +1018,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should reject message with mismatched version', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 const config = instance.config;
@@ -1060,7 +1060,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should accept message without bunnyBus header when overridden', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 const validatePublisher = false;
@@ -1095,7 +1095,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should accept message with bunnyBus header with mismatched version when overriden', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 const validateVersion = false;
@@ -1140,7 +1140,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1158,7 +1158,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1171,7 +1171,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Object) from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[subscriptionKey] = (consumedMessage, ack) => {
@@ -1203,7 +1203,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1221,7 +1221,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1234,7 +1234,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message (Object) from queue and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers[subscriptionKey] = (consumedMessage, ack) => {
@@ -1265,7 +1265,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1278,7 +1278,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         afterEach(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.parallel([
                     instance.unsubscribe.bind(instance, queueName1),
@@ -1289,7 +1289,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1302,7 +1302,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should consume message from two queues and acknowledge off', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 let counter = 0;
@@ -1342,7 +1342,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1364,7 +1364,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1376,7 +1376,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should ack a message off the queue', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance.publish.bind(instance, message),
@@ -1410,7 +1410,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1432,7 +1432,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1444,7 +1444,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should requeue a message off the queue', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance.publish.bind(instance, message),
@@ -1466,7 +1466,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should requeue with well formed header properties', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const publishOptions = {
                     source : 'test'
@@ -1515,7 +1515,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1537,7 +1537,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -1554,7 +1554,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should reject a message off the queue', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance.publish.bind(instance, message),
@@ -1576,7 +1576,7 @@ describe('positive integration tests with configuration - Callback api', () => {
 
         it('should reject with well formed header properties', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const publishOptions = {
                     source : 'test'
@@ -1632,7 +1632,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoConnectionError when connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance._createChannel((err) => {
 
@@ -1654,7 +1654,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling createQueue and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.createQueue(queueName, (err) => {
 
@@ -1666,7 +1666,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling checkQueue and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.checkQueue(queueName, (err) => {
 
@@ -1678,7 +1678,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling deleteQueue and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.deleteQueue(queueName, (err) => {
 
@@ -1700,7 +1700,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling createExchange and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.createExchange(exchangeName, '', (err) => {
 
@@ -1712,7 +1712,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling checkExchange and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.checkExchange(exchangeName, (err) => {
 
@@ -1724,7 +1724,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling deleteExchange and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.deleteExchange(exchangeName, (err) => {
 
@@ -1746,7 +1746,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling get and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.get(queueName, (err) => {
 
@@ -1763,7 +1763,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoRouteKeyError when calling publish and `options.routeKey` nor `message.event` exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.publish(message, (err) => {
 
@@ -1788,7 +1788,7 @@ describe('negative integration tests', () => {
 
         it('should throw SubscriptionExistError when calling subscribe on an active subscription exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.subscriptions.create(queueName, handlers);
                 instance.subscriptions.tag(queueName, consumerTag);
@@ -1803,7 +1803,7 @@ describe('negative integration tests', () => {
 
         it('should throw SubscriptionBlockedError when calling subscribe against a blocked queue', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.subscriptions.block(queueName);
 
@@ -1829,7 +1829,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling _ack and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance._ack(payload, (err) => {
 
@@ -1853,7 +1853,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling _requeue and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance._requeue(payload, '', (err) => {
 
@@ -1877,7 +1877,7 @@ describe('negative integration tests', () => {
 
         it('should throw NoChannelError when calling _reject and connection does not pre-exist', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance._reject(payload, '', (err) => {
 

--- a/test/node6/integration-edge-case.js
+++ b/test/node6/integration-edge-case.js
@@ -3,7 +3,7 @@
 const Async = require('async');
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
-const { Promisify, PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const before = lab.before;
@@ -35,7 +35,7 @@ describe('positive integration tests - Callback api', () => {
 
         it('should pass when parallel calls to publish happens when connection starts off closed', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const message = { event : 'ee', name : 'bunnybus' };
 
@@ -54,7 +54,7 @@ describe('positive integration tests - Callback api', () => {
 
         it('should pass when send pushes a message to a subscribed queue', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const message = { event : 'ea', name : 'bunnybus' };
                 const queueName = 'edge-case-get-to-subscribe';
@@ -85,7 +85,7 @@ describe('positive integration tests - Callback api', () => {
 
         it('should pass when server host configuration value is not valid', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const message = { event : 'eb', name : 'bunnybus' };
                 instance.config = { server : 'fake' };

--- a/test/node6/integration-event-handlers.js
+++ b/test/node6/integration-event-handlers.js
@@ -3,7 +3,7 @@
 const Async = require('async');
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
-const { PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const before = lab.before;
@@ -32,7 +32,7 @@ describe('positive integration tests - event handlers', () => {
 
         beforeEach(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers['subscribed-event'] = (consumedMessage, ack, reject, requeue) => {};
@@ -48,7 +48,7 @@ describe('positive integration tests - event handlers', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -60,7 +60,7 @@ describe('positive integration tests - event handlers', () => {
 
         it('should cause `unsubscribed()` to be called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.UNSUBSCRIBED_EVENT, (queue) => {
 
@@ -87,7 +87,7 @@ describe('positive integration tests - event handlers', () => {
 
         afterEach(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.channel.cancel(instance.subscriptions.get(queueName).consumerTag, (err) => {
 
@@ -100,7 +100,7 @@ describe('positive integration tests - event handlers', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -112,7 +112,7 @@ describe('positive integration tests - event handlers', () => {
 
         it('should cause `subscribed()` to be called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.SUBSCRIBED_EVENT, (queue) => {
 

--- a/test/node6/integration-events.js
+++ b/test/node6/integration-events.js
@@ -3,7 +3,7 @@
 const Async = require('async');
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
-const { Promisify, PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const before = lab.before;
@@ -35,7 +35,7 @@ describe('positive integration tests - events', () => {
 
         it('should be evented when connection was closed and is recovering', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.RECOVERING_EVENT, done);
 
@@ -45,7 +45,7 @@ describe('positive integration tests - events', () => {
 
         it('should be evented when channel was closed and is recovering', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.RECOVERING_EVENT, done);
 
@@ -63,7 +63,7 @@ describe('positive integration tests - events', () => {
 
         it('should be evented when connection was closed and is recovering', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.RECOVERED_EVENT, done);
 
@@ -73,7 +73,7 @@ describe('positive integration tests - events', () => {
 
         it('should be evented when channel was closed and is recovering', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.RECOVERED_EVENT, done);
 
@@ -88,7 +88,7 @@ describe('positive integration tests - events', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -99,7 +99,7 @@ describe('positive integration tests - events', () => {
 
         it('should be evented when message is published', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.PUBLISHED_EVENT, (sentMessage) => {
 
@@ -118,7 +118,7 @@ describe('positive integration tests - events', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -130,7 +130,7 @@ describe('positive integration tests - events', () => {
 
         afterEach(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.channel.cancel(instance.subscriptions.get(queueName).consumerTag, (err) => {
 
@@ -143,7 +143,7 @@ describe('positive integration tests - events', () => {
 
         it('should be evented when queue is subscribed', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers['subscribed-event'] = (consumedMessage, ack, reject, requeue) => {};
@@ -165,7 +165,7 @@ describe('positive integration tests - events', () => {
 
         beforeEach(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 const handlers = {};
                 handlers['subscribed-event'] = (consumedMessage, ack, reject, requeue) => {};
@@ -176,7 +176,7 @@ describe('positive integration tests - events', () => {
 
         it('should be evented when queue is unsubscribed', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.once(BunnyBus.UNSUBSCRIBED_EVENT, (queue) => {
 

--- a/test/node6/integration-promise.js
+++ b/test/node6/integration-promise.js
@@ -4,7 +4,7 @@ const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const Exceptions = require('../../lib/exceptions');
 const Assertions = require('./assertions');
-const { Promisify, PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const before = lab.before;
@@ -156,7 +156,7 @@ describe('positive integration tests - Promise api', () => {
 
         it('should recreate connection when connection error occurs', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.connection.emit('error');
 
@@ -171,7 +171,7 @@ describe('positive integration tests - Promise api', () => {
 
         it('should recreate connection when channel error occurs', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.channel.emit('error');
 

--- a/test/node6/load.js
+++ b/test/node6/load.js
@@ -2,7 +2,7 @@
 
 const Async = require('async');
 const Lab = require('@hapi/lab');
-const { PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 const Bluebird = require('bluebird');
 
 const lab = exports.lab = Lab.script();
@@ -35,7 +35,7 @@ describe('integration load test', () => {
 
         before(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -57,7 +57,7 @@ describe('integration load test', () => {
 
         afterEach(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -68,7 +68,7 @@ describe('integration load test', () => {
 
         after(async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Async.waterfall([
                     instance._autoConnectChannel,
@@ -81,7 +81,7 @@ describe('integration load test', () => {
 
         it('should publish all messages within 2 seconds', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 let count = 0;
 
@@ -103,7 +103,7 @@ describe('integration load test', () => {
 
         it('should consume all messages within 2 seconds', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 let count = 0;
 
@@ -176,7 +176,7 @@ describe('integration load test', () => {
 
         it('should consume all messages within 2 seconds', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 let count = 0;
 
@@ -254,7 +254,7 @@ describe('integration load test', () => {
 
         it('should consume all messages within 2 seconds', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 let count = 0;
 

--- a/test/node6/logging.js
+++ b/test/node6/logging.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Lab = require('@hapi/lab');
-const { PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const before = lab.before;
@@ -30,7 +30,7 @@ describe('logging', () => {
 
         it('should subscribe to `log.info` event when log.info() is called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertLogger(instance, 'info', inputMessage, done);
             });
@@ -38,7 +38,7 @@ describe('logging', () => {
 
         it('should subscribe to `log.error` event when log.error() is called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertLogger(instance, 'error', inputMessage, done);
             });
@@ -46,7 +46,7 @@ describe('logging', () => {
 
         it('should subscribe to `log.warn` event when log.warn() is called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertLogger(instance, 'warn', inputMessage, done);
             });
@@ -54,7 +54,7 @@ describe('logging', () => {
 
         it('should subscribe to `log.fatal` event when log.fatal() is called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertLogger(instance, 'fatal', inputMessage, done);
             });
@@ -62,7 +62,7 @@ describe('logging', () => {
 
         it('should subscribe to `log.debug` event when log.debug() is called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertLogger(instance, 'debug', inputMessage, done);
             });
@@ -70,7 +70,7 @@ describe('logging', () => {
 
         it('should subscribe to `log.trace` event when log.trace() is called', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertLogger(instance, 'trace', inputMessage, done);
             });
@@ -81,7 +81,7 @@ describe('logging', () => {
 
         it('should call custom info handler', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertCustomLogger(instance, 'info', inputMessage, done);
             });
@@ -89,7 +89,7 @@ describe('logging', () => {
 
         it('should call custom error handler', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertCustomLogger(instance, 'error', inputMessage, done);
             });
@@ -97,7 +97,7 @@ describe('logging', () => {
 
         it('should call custom warn handler', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertCustomLogger(instance, 'warn', inputMessage, done);
             });
@@ -105,7 +105,7 @@ describe('logging', () => {
 
         it('should call custom fatal handler', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertCustomLogger(instance, 'fatal', inputMessage, done);
             });
@@ -113,7 +113,7 @@ describe('logging', () => {
 
         it('should call custom debug handler', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertCustomLogger(instance, 'debug', inputMessage, done);
             });
@@ -121,7 +121,7 @@ describe('logging', () => {
 
         it('should call custom trace handler', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 Assertions.assertCustomLogger(instance, 'trace', inputMessage, done);
             });

--- a/test/node6/states.js
+++ b/test/node6/states.js
@@ -2,7 +2,7 @@
 
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
-const { PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const describe = lab.describe;
@@ -64,7 +64,7 @@ describe('state management', () => {
 
             it('should subscribe to `subscription.created` event', async () => {
 
-                return PromisifyWrap((done) => {
+                return Promisify((done) => {
 
                     const queueName = `${baseQueueName}-3`;
                     const handlers = { event1 : () => {} };
@@ -115,7 +115,7 @@ describe('state management', () => {
 
             it('should subscribe to `subscription.tagged` event', async () => {
 
-                return PromisifyWrap((done) => {
+                return Promisify((done) => {
 
                     const queueName = `${baseQueueName}-3`;
                     const consumerTag = 'abcdefg012345';
@@ -212,7 +212,7 @@ describe('state management', () => {
 
             it('should subscribe to `subscription.cleared` event', async () => {
 
-                return PromisifyWrap((done) => {
+                return Promisify((done) => {
 
                     const queueName = `${baseQueueName}-4`;
                     const consumerTag = 'abcdefg012345';
@@ -238,7 +238,7 @@ describe('state management', () => {
 
             it('should return true when subscription is cleared', async () => {
 
-                return PromisifyWrap((done) => {
+                return Promisify((done) => {
 
                     const handlers = { event1 : () => {} };
                     const options = {};
@@ -351,7 +351,7 @@ describe('state management', () => {
 
             it('should subscribe to `subscription.removed` event', async () => {
 
-                return PromisifyWrap((done) => {
+                return Promisify((done) => {
 
                     const queueName = `${baseQueueName}-4`;
                     const handlers = { event1 : () => {} };
@@ -431,7 +431,7 @@ describe('state management', () => {
 
             it('should subscribe to `subscription.blocked` event', async () => {
 
-                return PromisifyWrap((done) => {
+                return Promisify((done) => {
 
                     const queueName = 'queue5';
 
@@ -447,7 +447,7 @@ describe('state management', () => {
 
             it('should subscribe to `subscription.unblocked` event', async () => {
 
-                return PromisifyWrap((done) => {
+                return Promisify((done) => {
 
                     const queueName = 'queue6';
 

--- a/test/node8/integration-async-await.js
+++ b/test/node8/integration-async-await.js
@@ -4,7 +4,7 @@ const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const Exceptions = require('../../lib/exceptions');
 const Assertions = require('./assertions');
-const { Promisify, PromisifyWrap } = require('../promisify');
+const { Promisify } = require('../promisify');
 
 const lab = exports.lab = Lab.script();
 const before = lab.before;
@@ -141,7 +141,7 @@ describe('positive integration tests - async/await with Promise api', () => {
 
         it('should recreate connection when connection error occurs', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.connection.emit('error');
 
@@ -156,7 +156,7 @@ describe('positive integration tests - async/await with Promise api', () => {
 
         it('should recreate connection when channel error occurs', async () => {
 
-            return PromisifyWrap((done) => {
+            return Promisify((done) => {
 
                 instance.channel.emit('error');
 

--- a/test/promisify.js
+++ b/test/promisify.js
@@ -20,22 +20,6 @@ const promisify = (func, ...parameters) => {
     });
 };
 
-const promisifyWrap = (func) => {
-
-    return new Promise((res, rej) => {
-
-        const done = (err) => {
-
-            return err
-                ? rej(err)
-                : res();
-        };
-
-        func(done);
-    });
-};
-
 module.exports = {
-    Promisify: promisify,
-    PromisifyWrap: promisifyWrap
+    Promisify: promisify
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During the previous adaptation of the test to use the newest `@hapi/code`, `PromisifyWrap` was introduced to help with testing of callback functions in a `async/await` world.  In the rush, duplicate `Promise` wrappers were introduced.  This body of work is to remove that excess.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.