### PR TITLE
added optionality to disable queue binding

### DIFF
--- a/API.md
+++ b/API.md
@@ -149,7 +149,9 @@ Setter and Getter for singleton configuration. Accepts the following optional pr
  * `prefetch` - value of the maximum number of unacknowledged messages allowable in a channel.  Defaults to `5`. *[number]* **Optional**
  * `maxRetryCount` - maximum amount of attempts a message can be requeued.  This is the default used when one is not provided within the `options` for any `BunnyBus` methods that supports one transactionally. Defaults to `10`. *[number]* **Optional**
  * `validatePublisher` - flag to dictate if the publishing source for messages being consumed must be `bunnyBus`.  This is a safe guard to prevent unexpected message sources from entering the subscribing realm. A value of `bunnyBus` is stamped as a header property on the message during `publish()`.  The `subscribe()` method will use the same value for authentication.  Consumers detecting mismatched publishers will auto reject the message into an error queue.  Defaults to `false`. *[boolean]* **Optional**
- * `validateVersion` - flag to dictate if major semver should be matched as part of the message subscription valiation.  This is a safe guard to prevent mismatched `bunnyBus` drivers from pub/sub to each other.  Consumers detecting mismatched major values will auto reject the message into an error queue.  In order for this layer of validation to occur, `validatePublisher` must be allowed because the version value is set against the `bunnyBus` header.   Defaults to `false`. *[boolean]* **Optional**
+ * `validateVersion` - flag to dictate if major semver should be matched as part of the message subscription validation.  This is a safe guard to prevent mismatched 
+ `bunnyBus` drivers from pub/sub to each other.  Consumers detecting mismatched major values will auto reject the message into an error queue.  In order for this layer of validation to occur, `validatePublisher` must be allowed because the version value is set against the `bunnyBus` header.   Defaults to `false`. *[boolean]* **Optional**
+ * `disableQueueBind` = flag to dictate if automatic queue binding should be turned on/off as part of the consume setup process.  Defaults to `false`.  *[boolean]* **Optional**
 
 Note that updates in the options directed at changing connection string will not take affect immediately.  [`_closeConnection()`](#_closeConnectioncallback) needs to be called manually to invoke a new connection with new settings.
 
@@ -464,6 +466,7 @@ Subscribe to messages from a given queue.
     - `maxRetryCount` - maximum amount of attempts a message can be requeued.  Defaults to one provided in the [config](#config). *[number]* **Optional**
     - `validatePublisher` - flag for validating messages having `bunnyBus` header.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
     - `validateVersion` - flag for validating messages generated from the same major version.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
+    - `disableQueueBind` - flag for disabling automatic queue binding.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* **Optional**
     - `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be a `Function` as `(message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
   - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**
 

--- a/lib/helpers/defaultConfiguration.js
+++ b/lib/helpers/defaultConfiguration.js
@@ -17,7 +17,8 @@ module.exports = {
         silence            : false,
         maxRetryCount      : 10,
         validatePublisher  : false,
-        validateVersion    : false
+        validateVersion    : false,
+        disableQueueBind   : false
     },
     queue : {
         exclusive : false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -602,6 +602,7 @@ class BunnyBus extends EventEmitter{
         const maxRetryCount = (options && options.maxRetryCount) || $.config.maxRetryCount;
         const validatePublisher = (options && options.hasOwnProperty('validatePublisher')) ? options.validatePublisher : $.config.validatePublisher;
         const validateVersion = (options && options.hasOwnProperty('validateVersion')) ? options.validateVersion : $.config.validateVersion;
+        const disableQueueBind = (options && options.hasOwnProperty('disableQueueBind')) ? options.disableQueueBind : $.config.disableQueueBind;
         const meta = (options && options.meta);
 
         Async.auto({
@@ -610,14 +611,19 @@ class BunnyBus extends EventEmitter{
             create_exchange: ['initialize', (results, cb) => $.createExchange(globalExchange, 'topic', null, cb)],
             bind_routes    : ['create_queue', 'create_exchange', (results, cb) => {
 
-                Async.mapValues(
-                    handlers,
-                    (handler, pattern, mapCB) => {
+                if (!disableQueueBind) {
+                    Async.mapValues(
+                        handlers,
+                        (handler, pattern, mapCB) => {
 
-                        $.channel.bindQueue(queue, globalExchange, pattern, null, mapCB);
-                    },
-                    cb
-                );
+                            $.channel.bindQueue(queue, globalExchange, pattern, null, mapCB);
+                        },
+                        cb
+                    );
+                }
+                else {
+                    cb();
+                }
             }],
             setup_consumer : ['create_queue', (results, cb) => {
 

--- a/test/node8/integration-async-await.js
+++ b/test/node8/integration-async-await.js
@@ -1113,7 +1113,6 @@ describe('negative integration tests', () => {
 
             try {
                 await instance._createChannel();
-                console.log('Foo');
                 return throwError();
             }
             catch (err) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created a new `disableQueueBind` flag to allow for selectively disabling automatic queue binding when `subscribe` is called.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.