### PR TITLE
New Event for Recovery Failure Scenarios

### DIFF
--- a/API.md
+++ b/API.md
@@ -105,6 +105,9 @@
   - [`BunnyBus.RECOVERED_CHANNEL_EVENT`](#bunnybusrecovered_channel_event)
     - [event key](#event-key-15)
     - [handler parameter(s)](#handler-parameters-15)
+  - [`BunnyBus.RECOVERY_FAILED_EVENT`](#bunnybusrecovery_failed_event)
+    - [event key](#event-key-16)
+    - [handler parameter(s)](#handler-parameters-16)
 - [`Connection`](#connection)
   - [Getters and Setters](#getters-and-setters-1)
     - [`name`](#name)
@@ -160,19 +163,19 @@
   - [Events](#events-3)
     - [`ChannelManager.AMQP_CHANNEL_ERROR_EVENT`](#channelmanageramqp_channel_error_event)
       - [key value](#key-value-6)
-      - [handler parmaeters](#handler-parmaeters-6)
+      - [handler parameters](#handler-parameters)
     - [`ChannelManager.AMQP_CHANNEL_CLOSE_EVENT`](#channelmanageramqp_channel_close_event)
       - [key value](#key-value-7)
-      - [handler parmaeters](#handler-parmaeters-7)
+      - [handler parmaeters](#handler-parmaeters-6)
     - [`ChannelManager.AMQP_CHANNEL_RETURN_EVENT`](#channelmanageramqp_channel_return_event)
       - [key value](#key-value-8)
-      - [handler parmaeters](#handler-parmaeters-8)
+      - [handler parmaeters](#handler-parmaeters-7)
     - [`ChannelManager.AMQP_CHANNEL_DRAIN_EVENT`](#channelmanageramqp_channel_drain_event)
       - [key value](#key-value-9)
-      - [handler parmaeters](#handler-parmaeters-9)
+      - [handler parmaeters](#handler-parmaeters-8)
     - [`ChannelManager.CHANNEL_REMOVED`](#channelmanagerchannel_removed)
       - [key value](#key-value-10)
-      - [handler parmaeters](#handler-parmaeters-10)
+      - [handler parmaeters](#handler-parmaeters-9)
 - [`ChannelManager`](#channelmanager)
   - [Methods](#methods-2)
     - [`async create(name, [queue = null], connectionContext, channelOptions)`](#async-createname-queue--null-connectioncontext-channeloptions)
@@ -193,7 +196,7 @@
   - [Events](#events-4)
     - [`ChannelManager.CHANNEL_REMOVED`](#channelmanagerchannel_removed-1)
       - [key value](#key-value-11)
-      - [handler parmaeters](#handler-parmaeters-11)
+      - [handler parmaeters](#handler-parmaeters-10)
 - [`SubscriptionManager`](#subscriptionmanager)
   - [Methods](#methods-3)
     - [`contains(queue, [withConsumerTag])`](#containsqueue-withconsumertag)
@@ -209,22 +212,22 @@
   - [Events](#events-5)
     - [`SubscriptionManager.CREATED_EVENT`](#subscriptionmanagercreated_event)
       - [key value](#key-value-12)
-      - [handler parmaeters](#handler-parmaeters-12)
+      - [handler parmaeters](#handler-parmaeters-11)
     - [`SubscriptionManager.TAGGED_EVENT`](#subscriptionmanagertagged_event)
       - [key value](#key-value-13)
-      - [handler parmaeters](#handler-parmaeters-13)
+      - [handler parmaeters](#handler-parmaeters-12)
     - [`SubscriptionManager.CLEARED_EVENT`](#subscriptionmanagercleared_event)
       - [key value](#key-value-14)
-      - [handler parmaeters](#handler-parmaeters-14)
+      - [handler parmaeters](#handler-parmaeters-13)
     - [`SubscriptionManager.REMOVED_EVENT`](#subscriptionmanagerremoved_event)
       - [key value](#key-value-15)
-      - [handler parmaeters](#handler-parmaeters-15)
+      - [handler parmaeters](#handler-parmaeters-14)
     - [`SubscriptionManager.BLOCKED_EVENT`](#subscriptionmanagerblocked_event)
       - [key value](#key-value-16)
-      - [handler parmaeters](#handler-parmaeters-16)
+      - [handler parmaeters](#handler-parmaeters-15)
     - [`SubscriptionManager.UNBLOCKED_EVENT`](#subscriptionmanagerunblocked_event)
       - [key value](#key-value-17)
-      - [handler parmaeters](#handler-parmaeters-17)
+      - [handler parmaeters](#handler-parmaeters-16)
 - [Error Types](#error-types)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -1045,6 +1048,26 @@ const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
 bunnyBus.on('BunnyBus.RECOVERED_CHANNEL_EVENT', (channelName) => {
+
+    // do work to handle the case when a connection or channel is having a failure
+});
+```
+
+### `BunnyBus.RECOVERY_FAILED_EVENT`
+
+#### event key
+
+* `bunnybus.recovery-failed` - emitted when recovery efforts leads to a failed state.
+
+#### handler parameter(s)
+
+* `err` - a error object of type `Error` *[Object]*
+
+```javascript
+const BunnyBus = require('bunnybus');
+const bunnyBus = new BunnyBus();
+
+bunnyBus.on('BunnyBus.RECOVERY_FAILED_EVENT', (err) => {
 
     // do work to handle the case when a connection or channel is having a failure
 });

--- a/lib/helpers/retryAsync.js
+++ b/lib/helpers/retryAsync.js
@@ -29,7 +29,7 @@ const retryAsync = async (asyncFunc, interval = 500, times = 100, errorFilterFun
     } while (!isCompleted && iteration < times);
 
     if (iteration === times) {
-        throw new Error('Exceeded maximum attempts of retries');
+        throw new Error(`Exceeded maximum attempts of retries of ${times}`);
     }
 
     if (isCompleted) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,7 +133,12 @@ class BunnyBus extends EventEmitter{
 
     static get RECOVERED_CHANNEL_EVENT() {
 
-        return 'bunnybux.recovered-channel';
+        return 'bunnybus.recovered-channel';
+    }
+
+    static get RECOVERY_FAILED_EVENT() {
+
+        return 'bunnybus.recovery-failed';
     }
 
     static get DEFAULT_CONNECTION_NAME() {
@@ -700,7 +705,7 @@ class BunnyBus extends EventEmitter{
             try {
                 const { queue } = $.channels.get(channelName);
 
-                if (queue && $.subscriptions.contains(queue)) {
+                if (queue && $.subscriptions.contains(queue, false)) {
                     const { handlers, options } = $.subscriptions.get(queue);
 
                     if (!$.subscriptions.isBlocked(queue)) {
@@ -711,10 +716,12 @@ class BunnyBus extends EventEmitter{
             }
             catch (err) {
                 $.logger.fatal('failed to recover, exiting process', err);
-                process.exit(1);
+                $.emit(BunnyBus.RECOVERY_FAILED_EVENT, err);
+                throw err;
             }
-
-            $._state.recoveryLock = false;
+            finally {
+                $._state.recoveryLock = false;
+            }
         }
     }
 }
@@ -754,11 +761,12 @@ internals.handlers[ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT] = async (conte
 
     $.logger.info('connection closed', context);
 
-    $.emit(BunnyBus.RECOVERING_CONNECTION_EVENT, context.name);
-
-    await $._recoverConnection();
-
-    $.emit(BunnyBus.RECOVERED_CONNECTION_EVENT, context.name);
+    try {
+        $.emit(BunnyBus.RECOVERING_CONNECTION_EVENT, context.name);
+        await $._recoverConnection();
+        $.emit(BunnyBus.RECOVERED_CONNECTION_EVENT, context.name);
+    }
+    catch (err) {}
 };
 
 internals.handlers[ChannelManager.AMQP_CHANNEL_ERROR_EVENT] = (err, context) => {
@@ -770,11 +778,12 @@ internals.handlers[ChannelManager.AMQP_CHANNEL_CLOSE_EVENT] = async (context) =>
 
     $.logger.info('channel closed', context);
 
-    $.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);
-
-    await $._recoverChannel(context.name);
-
-    $.emit(BunnyBus.RECOVERED_CHANNEL_EVENT, context.name);
+    try {
+        $.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);
+        await $._recoverChannel(context.name);
+        $.emit(BunnyBus.RECOVERED_CHANNEL_EVENT, context.name);
+    }
+    catch (err) {}
 };
 
 module.exports = BunnyBus;

--- a/lib/states/channelManager.js
+++ b/lib/states/channelManager.js
@@ -34,6 +34,11 @@ class Channel extends EventEmitter {
         return this._connectionContext;
     }
 
+    set connectionContext(value) {
+
+        this._connectionContext = value;
+    }
+
     get channelOptions() {
 
         return this._channelOptions;
@@ -114,6 +119,8 @@ class ChannelManager extends EventEmitter {
             ? this._channels.get(name)
             : new Channel(name, queue, connectionContext, channelOptions);
 
+        channelContext.connectionContext = connectionContext;
+
         if (channelContext.channel) {
             return channelContext;
         }
@@ -130,7 +137,7 @@ class ChannelManager extends EventEmitter {
                 async () => {
 
                     channelContext.lock = true;
-                    channelContext.channel = await Helpers.timeoutAsync(connectionContext.connection.createConfirmChannel.bind(connectionContext.connection), channelOptions.timeout)();
+                    channelContext.channel = await Helpers.timeoutAsync(connectionContext.connection.createConfirmChannel.bind(connectionContext.connection), channelContext.channelOptions.timeout)();
                     channelContext.channel
                         .on('close', () => {
 

--- a/lib/states/connectionManager.js
+++ b/lib/states/connectionManager.js
@@ -132,7 +132,7 @@ class ConnectionManager extends EventEmitter {
                 await Helpers.retryAsync(
                     async () => {
 
-                        connectionContext.connection = await Helpers.timeoutAsync(Amqp.connect, connectionOptions.timeout)(connectionOptions, socketOptions);
+                        connectionContext.connection = await Helpers.timeoutAsync(Amqp.connect, connectionContext.connectionOptions.timeout)(connectionContext.connectionOptions, connectionContext.socketOptions);
                         connectionContext.connection
                             .on('close', () => {
 

--- a/test/BunnyBus/end-to-end/load.js
+++ b/test/BunnyBus/end-to-end/load.js
@@ -66,6 +66,9 @@ describe('BunnyBus', () => {
 
                 const promises = [];
 
+                // Do this to primse the connection
+                await instance.publish(message);
+
                 for (let i = 0; i < publishTarget; ++i) {
                     promises.push(instance.publish(message));
                 }

--- a/test/BunnyBus/events/recovery.js
+++ b/test/BunnyBus/events/recovery.js
@@ -3,6 +3,7 @@
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const BunnyBus = require('../../../lib');
+const { ChannelManager } = require('../../../lib/states');
 
 const { describe, before, beforeEach, after, afterEach, it } = exports.lab = Lab.script();
 const expect = Code.expect;
@@ -18,7 +19,7 @@ describe('BunnyBus', () => {
         before(async () => {
 
             instance = new BunnyBus();
-            instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+            // instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
             connectionManager = instance.connections;
             channelManager = instance.channels;
         });
@@ -30,92 +31,161 @@ describe('BunnyBus', () => {
 
             beforeEach(async () => {
 
+                instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+
                 await instance._autoBuildChannelContext(baseChannelName);
             });
 
             it('should emit RECOVERING_CONNECTION_EVENT when closed connection is recovering', async () => {
 
-                await new Promise((resolve) => {
+                const promise = new Promise((resolve) => {
 
                     instance.once(BunnyBus.RECOVERING_CONNECTION_EVENT, (connectionName) => {
 
                         expect(connectionName).to.equal(BunnyBus.DEFAULT_CONNECTION_NAME);
                         resolve();
                     });
-
-                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
                 });
+
+                await Promise.all([
+                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME),
+                    promise
+                ]);
             });
 
             it('should emit RECOVERING_CHANNEL_EVENT when closed connection is recovering', async () => {
 
-                await new Promise((resolve) => {
+                const promise = new Promise((resolve) => {
 
                     instance.once(BunnyBus.RECOVERING_CHANNEL_EVENT, (channelName) => {
 
                         expect(channelName).to.equal(baseChannelName);
                         resolve();
                     });
-
-                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
                 });
+
+                await Promise.all([
+                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME),
+                    promise
+                ]);
             });
 
             it('should emit RECOVERING_CHANNEL_EVENT when closed connection is recovering', async () => {
 
-                await new Promise((resolve) => {
+                const promise = new Promise((resolve) => {
 
                     instance.once(BunnyBus.RECOVERING_CHANNEL_EVENT, (channelName) => {
 
                         expect(channelName).to.equal(baseChannelName);
                         resolve();
                     });
-
-                    channelManager.close(baseChannelName);
                 });
+
+                await Promise.all([
+                    channelManager.close(baseChannelName),
+                    promise
+                ]);
             });
 
             it('should emit RECOVERED_CONNECTION_EVENT when closed connection is recovered', async () => {
 
-                await new Promise((resolve) => {
+                const promise = new Promise((resolve) => {
 
                     instance.once(BunnyBus.RECOVERED_CONNECTION_EVENT, (connectionName) => {
 
                         expect(connectionName).to.equal(BunnyBus.DEFAULT_CONNECTION_NAME);
                         resolve();
                     });
-
-                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
                 });
-            });
 
+                await Promise.all([
+                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME),
+                    promise
+                ]);
+            });
 
             it('should emit RECOVERED_CHANNEL_EVENT when closed connection is recovered', async () => {
 
-                await new Promise((resolve) => {
+                const promise = new Promise((resolve) => {
 
                     instance.once(BunnyBus.RECOVERED_CHANNEL_EVENT, (channelName) => {
 
                         expect(channelName).to.equal(baseChannelName);
                         resolve();
                     });
-
-                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
                 });
+
+                await Promise.all([
+                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME),
+                    promise
+                ]);
             });
 
             it('should emit RECOVERED_CHANNEL_EVENT when closed connection is recovering', async () => {
 
-                await new Promise((resolve) => {
+                const promise = new Promise((resolve) => {
 
                     instance.once(BunnyBus.RECOVERED_CHANNEL_EVENT, (channelName) => {
 
                         expect(channelName).to.equal(baseChannelName);
                         resolve();
                     });
-
-                    channelManager.close(baseChannelName);
                 });
+
+                await Promise.all([
+                    channelManager.close(baseChannelName),
+                    promise
+                ]);
+            });
+
+            it('should emit RECOVERY_FAILED_EVENT when recovery process fails', { timeout: 6000 }, async () => {
+
+                // Setup a subscripton so recovery is necessary.
+                await instance.subscribe(baseQueueName, {
+                    'subscribed-event': () => {}
+                });
+
+                // Make sure connection/channel state is in a good place.
+                expect(connectionManager.get(BunnyBus.DEFAULT_CONNECTION_NAME).connection).to.exist();
+                expect(channelManager.get(BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName)).channel).to.exist();
+
+                // Inject a poison configuration value.
+                instance.config = Object.assign({}, BunnyBus.DEFAULT_SERVER_CONFIGURATION, { hostname: 'fake', timeout: 300,  connectionRetryCount: 1 });
+                connectionManager.get(BunnyBus.DEFAULT_CONNECTION_NAME)._connectionOptions = Object.assign({}, BunnyBus.DEFAULT_SERVER_CONFIGURATION, { hostname: 'fake', timeout: 300,  connectionRetryCount: 1 });
+                // Highjack the recovery state because previous test might have left this in a bad place
+                instance._state.recoveryLock = false;
+
+                // Should reach this since we exceed retry attemps
+                const errorPromise = new Promise((resolve) => {
+
+                    instance.once(BunnyBus.RECOVERY_FAILED_EVENT, (err) => {
+
+                        expect(err).to.be.an.error('Exceeded maximum attempts of retries of 1');
+                        resolve();
+                    });
+                });
+
+                // Initiate test
+                await Promise.all([
+                    connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME),
+                    errorPromise
+                ]);
+
+                // Everything below here is just clean up.
+                instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+
+                instance.subscriptions.remove(baseQueueName);
+
+                const cleanupPromise = new Promise(async (resolve) => {
+
+                    channelManager.once(ChannelManager.CHANNEL_REMOVED, resolve);
+                });
+
+                await Promise.all([
+                    connectionManager.remove(BunnyBus.DEFAULT_CONNECTION_NAME),
+                    channelManager.remove(BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName)),
+                    cleanupPromise
+                ]);
             });
         });
     });

--- a/test/helpers/retryAsync.js
+++ b/test/helpers/retryAsync.js
@@ -127,7 +127,7 @@ describe('Helpers', () => {
             }
 
             expect(i).to.equal(2);
-            expect(result).to.be.an.error(Error, 'Exceeded maximum attempts of retries');
+            expect(result).to.be.an.error(Error, 'Exceeded maximum attempts of retries of 2');
         });
 
         it('should error when error filter trips', async () => {

--- a/test/states/channelManager.js
+++ b/test/states/channelManager.js
@@ -132,7 +132,7 @@ describe('state management', () => {
                 }
 
                 expect(sut).to.exist();
-                expect(sut).to.be.an.error('Exceeded maximum attempts of retries');
+                expect(sut).to.be.an.error('Exceeded maximum attempts of retries of 1');
             });
         });
 

--- a/test/states/connectionManager.js
+++ b/test/states/connectionManager.js
@@ -117,7 +117,7 @@ describe('state management', () => {
                 }
 
                 expect(sut).to.exist();
-                expect(sut).to.be.an.error('Exceeded maximum attempts of retries');
+                expect(sut).to.be.an.error('Exceeded maximum attempts of retries of 1');
             });
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New event named `BunnyBus.RECOVERY_FAILED_EVENT` which is emitted by a failed connection or channel recovery event.  It should be noted here that connection and channel recover are only done when handler subscription exist.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.