### PR TITLE
Reverted Log Param Arity to One

### DIFF
--- a/API.md
+++ b/API.md
@@ -336,16 +336,17 @@ const bunnyBus = new BunnyBus();
 
 const logHandler = (message) => {
 
-    //log something to some where
+    //forward the message to some where such as
+    //process.stdout or console.log or syslog.
 };
 
 //custom logger
 bunnyBus.logger = {
-    info  = logHandler,
-    debug = logHandler,
-    warn  = logHandler,
-    error = logHandler,
-    fatal = logHandler
+    info  : logHandler,
+    debug : logHandler,
+    warn  : logHandler,
+    error : logHandler,
+    fatal : logHandler
 };
 ```
 

--- a/Example.md
+++ b/Example.md
@@ -227,8 +227,8 @@ const app = require('express')();
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-bunnyBus.on(BunnyBus.LOG_INFO_EVENT, (...message) => [
+bunnyBus.on(BunnyBus.LOG_INFO_EVENT, (message) => [
 
-    console.log(...message);
+    console.log(message);
 ]);
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -715,7 +715,8 @@ class BunnyBus extends EventEmitter{
                 }
             }
             catch (err) {
-                $.logger.fatal('failed to recover, exiting process', err);
+                err.bunnyBusMessage = 'failed to recover, exiting process';
+                $.logger.fatal(err);
                 $.emit(BunnyBus.RECOVERY_FAILED_EVENT, err);
                 throw err;
             }
@@ -734,6 +735,7 @@ internals.handlers[SubscriptionManager.BLOCKED_EVENT] = async (queue) => {
         await $.unsubscribe(queue);
     }
     catch (err) {
+        err.bunnyBusMessage = 'blocked event handling failed';
         $.logger.error(err);
     }
 };
@@ -748,18 +750,21 @@ internals.handlers[SubscriptionManager.UNBLOCKED_EVENT] = async (queue) => {
         await $.subscribe(queue, subscription.handlers, subscription.options);
     }
     catch (err) {
+        err.bunnyBusMessage = 'unblocked event handling failed';
         $.logger.error(err);
     }
 };
 
 internals.handlers[ConnectionManager.AMQP_CONNECTION_ERROR_EVENT] = (err, context) => {
 
-    $.logger.error('connection errored', err, context);
+    err.bunnyBusMessage = 'connection error';
+    err.context = context;
+    $.logger.error(err);
 };
 
 internals.handlers[ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT] = async (context) => {
 
-    $.logger.info('connection closed', context);
+    $.logger.info(`${context.name} connection closed`);
 
     try {
         $.emit(BunnyBus.RECOVERING_CONNECTION_EVENT, context.name);
@@ -771,12 +776,14 @@ internals.handlers[ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT] = async (conte
 
 internals.handlers[ChannelManager.AMQP_CHANNEL_ERROR_EVENT] = (err, context) => {
 
-    $.logger.error('channel errored', err, context);
+    err.bunnyBusMessage = 'channel errored';
+    err.context = context;
+    $.logger.error(err);
 };
 
 internals.handlers[ChannelManager.AMQP_CHANNEL_CLOSE_EVENT] = async (context) => {
 
-    $.logger.info('channel closed', context);
+    $.logger.info(`${context.name} channel closed`);
 
     try {
         $.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);

--- a/lib/loggers/eventLogger.js
+++ b/lib/loggers/eventLogger.js
@@ -32,29 +32,29 @@ class EventLogger {
         return 'log.fatal';
     }
 
-    debug(...args) {
+    debug(data) {
 
-        this._eventEmitter.emit(EventLogger.LOG_DEBUG_EVENT, ...args);
+        this._eventEmitter.emit(EventLogger.LOG_DEBUG_EVENT, data);
     }
 
-    info(...args) {
+    info(data) {
 
-        this._eventEmitter.emit(EventLogger.LOG_INFO_EVENT, ...args);
+        this._eventEmitter.emit(EventLogger.LOG_INFO_EVENT, data);
     }
 
-    warn(...args) {
+    warn(data) {
 
-        this._eventEmitter.emit(EventLogger.LOG_WARN_EVENT, ...args);
+        this._eventEmitter.emit(EventLogger.LOG_WARN_EVENT, data);
     }
 
-    error(...args) {
+    error(data) {
 
-        this._eventEmitter.emit(EventLogger.LOG_ERROR_EVENT, ...args);
+        this._eventEmitter.emit(EventLogger.LOG_ERROR_EVENT, data);
     }
 
-    fatal(...args) {
+    fatal(data) {
 
-        this._eventEmitter.emit(EventLogger.LOG_FATAL_EVENT, ...args);
+        this._eventEmitter.emit(EventLogger.LOG_FATAL_EVENT, data);
     }
 }
 

--- a/test/BunnyBus/logger.js
+++ b/test/BunnyBus/logger.js
@@ -56,23 +56,21 @@ describe('BunnyBus', () => {
                     await Assertions.assertLogger(instance, 'debug', inputMessage);
                 });
 
-                it('should subscribe to `log.info` event when log.inf() is called with multiple arguments', async () => {
+                it('should subscribe to `log.info` event when log.inf0() is called with multiple arguments', async () => {
 
                     const arg1 = 'foo';
-                    const arg2 = { hello: 'world' };
 
                     const promise = new Promise((resolve) => {
 
-                        instance.once(BunnyBus.LOG_INFO_EVENT, (sentArg1, sentArg2) => {
+                        instance.once(BunnyBus.LOG_INFO_EVENT, (sentArg1) => {
 
                             expect(sentArg1).to.equal(arg1);
-                            expect(sentArg2).to.contains(arg2);
 
                             resolve();
                         });
                     });
 
-                    instance.logger.info(arg1, arg2);
+                    instance.logger.info(arg1);
                     await promise;
                 });
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reverted logging contract for all levels from `logger.info(...args)` to `logger.info(data)`.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Realization that not all logging contracts support n-arity.  `hapi` specifically only supports a single data parameter.  It has a contract of `*.log(tags, [data, [timestamp]])`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.