### PR TITLE
adding lint rule for unquoted props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
     "rules": {
         "consistent-this" : [ 0, "self", "$" ],
         "require-await": "off",
-        "no-unused-vars": "off"
+        "no-unused-vars": "off",
+        "quote-props": [ "error", "consistent-as-needed", { "unnecessary" : true, "numbers" : true }]
     },
     "parserOptions": {
         "ecmaVersion": 8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added new lint rule to handle quoted props

`"quote-props": [ "error", "consistent-as-needed", { "unnecessary" : true, "numbers" : true }]`

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.