### PR TITLE
Converted to Optional Singleton Model

### DIFF
--- a/API.md
+++ b/API.md
@@ -6,7 +6,7 @@
 
 - [BunnyBus](#bunnybus)
   - [Constructor](#constructor)
-    - [`new BunnyBus(config)`](#new-bunnybusconfig)
+    - [`new BunnyBus([config])`](#new-bunnybusconfig)
   - [Getters and Setters](#getters-and-setters)
     - [`config`](#config)
     - [`connections`](#connections)
@@ -14,6 +14,8 @@
     - [`subscriptions`](#subscriptions)
     - [`logger`](#logger)
     - [`connectionString`](#connectionstring)
+  - [Static Methods](#static-methods)
+    - [`Singleton([config])`](#singletonconfig)
   - [Methods](#methods)
     - [`async createExchange(name, type, [options])`](#async-createexchangename-type-options)
       - [parameter(s)](#parameters)
@@ -242,9 +244,9 @@ A note regarding versioning:  `BunnyBus` attaches the version value found in its
 
 ### Constructor
 
-#### `new BunnyBus(config)`
+#### `new BunnyBus([config])`
 
-Creates a new singleton instance of `bunnybus`. Accepts a configuration parameter. See [`config`](#config) for allowed options.
+Creates a new instance of `bunnybus`. Accepts a configuration parameter. See [`config`](#config) for allowed options.
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -361,6 +363,19 @@ const bunnyBus = new BunnyBus();
 
 console.log(bunnyBus.connectionString);
 //output : amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=2000
+```
+
+### Static Methods
+
+#### `Singleton([config])`
+
+Retrieves a singleton instance of BunnyBus. Accepts a configuration parameter. See [`config`](#config) for allowed options.
+
+```javascript
+const BunnyBus = require('bunnybus');
+const bunnyBus = BunnyBus.Singleton({ hostname : 'red-bee.cloudamqp.com' });
+
+//do work;
 ```
 
 ### Methods

--- a/API.md
+++ b/API.md
@@ -236,7 +236,7 @@
 
 ## BunnyBus
 
-`BunnyBus` is a class that instantiates into a singleton.  It hosts all features for communicating with RabbitMQ to provide an easy to use enterprise bus facade.
+`BunnyBus` is a class that hosts all features for communicating with RabbitMQ to provide an easy to use enterprise bus facade.
 
 **Note About Versioning**
 
@@ -259,7 +259,7 @@ const bunnyBus = new BunnyBus({ hostname : 'red-bee.cloudamqp.com' });
 
 #### `config`
 
-Setter and Getter for singleton configuration. Accepts the following optional properties:
+Setter and Getter for configuration. Accepts the following optional properties:
 
  * `protocol` - value for creating a secure connection.  Used in the connection string.  Defaults to `amqp`. *[string]* **Optional**
  * `username` - value of the username.  Used in the connection string.  Defaults to `guest`. *[string]* **Optional**
@@ -369,7 +369,7 @@ console.log(bunnyBus.connectionString);
 
 #### `Singleton([config])`
 
-Retrieves a singleton instance of BunnyBus. Accepts a configuration parameter. See [`config`](#config) for allowed options.
+Sets up new, or retrieves an existing singleton instance of BunnyBus. Accepts a configuration parameter. See [`config`](#config) for allowed options.
 
 ```javascript
 const BunnyBus = require('bunnybus');

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,40 +7,49 @@ const { ChannelManager, ConnectionManager, SubscriptionManager } = require('./st
 const { SerialDispatcher, ConcurrentDispatcher } = require('./schedulers');
 const { EventLogger } = require('./loggers');
 
-let $ = undefined;
+let singleton = undefined;
 
 class BunnyBus extends EventEmitter{
 
     constructor(config) {
 
-        if (!$) {
-            super();
+        super();
 
-            $ = this;
+        this._state = {
+            recoveryLock    : false
+        };
 
-            $._state = {
-                recoveryLock    : false
-            };
+        this.logger = new EventLogger(this);
+        this._subscriptions = new SubscriptionManager();
+        this._connections = new ConnectionManager();
+        this._channels = new ChannelManager();
+        this._dispatchers = {
+            serial: new SerialDispatcher(),
+            concurrent: new ConcurrentDispatcher()
+        };
+        this._handlerAssignmentLedger = new Map();
 
-            $.logger = new EventLogger($);
-            $._subscriptions = new SubscriptionManager();
-            $._connections = new ConnectionManager();
-            $._channels = new ChannelManager();
-            $._dispatchers = {
-                serial: new SerialDispatcher(),
-                concurrent: new ConcurrentDispatcher()
-            };
-            $._handlerAssignmentLedger = new Map();
+        this._subscriptions.on(SubscriptionManager.BLOCKED_EVENT, this._on_subscriptionManager_BLOCKED_EVENT.bind(this));
+        this._subscriptions.on(SubscriptionManager.UNBLOCKED_EVENT, this._on_subscriptionManager_UNBLOCKED_EVENT.bind(this));
 
-            $._subscriptions.on(SubscriptionManager.BLOCKED_EVENT, $._on_subscriptionManager_BLOCKED_EVENT.bind($));
-            $._subscriptions.on(SubscriptionManager.UNBLOCKED_EVENT, $._on_subscriptionManager_UNBLOCKED_EVENT.bind($));
+        if (config) {
+            this.config = config;
+        }
+
+        return this;
+    }
+
+    static Singleton(config) {
+
+        if (!singleton) {
+            singleton = new BunnyBus();
         }
 
         if (config) {
-            $.config = config;
+            singleton.config = config;
         }
 
-        return $;
+        return singleton;
     }
 
     static get DEFAULT_SERVER_CONFIGURATION() {
@@ -165,32 +174,32 @@ class BunnyBus extends EventEmitter{
 
     get config() {
 
-        return $._config || BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+        return this._config || BunnyBus.DEFAULT_SERVER_CONFIGURATION;
     }
 
     set config(value) {
 
-        $._config = Object.assign({}, $._config || BunnyBus.DEFAULT_SERVER_CONFIGURATION, value);
+        this._config = Object.assign({}, this._config || BunnyBus.DEFAULT_SERVER_CONFIGURATION, value);
     }
 
     get subscriptions() {
 
-        return $._subscriptions;
+        return this._subscriptions;
     }
 
     get connections() {
 
-        return $._connections;
+        return this._connections;
     }
 
     get channels() {
 
-        return $._channels;
+        return this._channels;
     }
 
     get logger() {
 
-        return $._logger;
+        return this._logger;
     }
 
     set logger(value) {
@@ -199,17 +208,17 @@ class BunnyBus extends EventEmitter{
             throw new Exceptions.IncompatibleLoggerError();
         }
 
-        $._logger = value;
+        this._logger = value;
     }
 
     get connectionString() {
 
-        return Helpers.createConnectionString($.config);
+        return Helpers.createConnectionString(this.config);
     }
 
     async createExchange(name, type, options) {
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
         //type : (direct, fanout, header, topic)
         return await channelContext.channel.assertExchange(name, type, Object.assign({}, BunnyBus.DEFAULT_EXCHANGE_CONFIGURATION, options));
@@ -217,7 +226,7 @@ class BunnyBus extends EventEmitter{
 
     async deleteExchange(name, options) {
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
         return await channelContext.channel.deleteExchange(name, options);
     }
@@ -226,7 +235,7 @@ class BunnyBus extends EventEmitter{
 
         let result = undefined;
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
         const promise = new Promise((resolve) => {
 
@@ -255,7 +264,7 @@ class BunnyBus extends EventEmitter{
             }
         }
         finally {
-            await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
         }
 
         return result;
@@ -263,7 +272,7 @@ class BunnyBus extends EventEmitter{
 
     async createQueue(name, options) {
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
         return await channelContext.channel.assertQueue(name, Object.assign({}, BunnyBus.DEFAULT_QUEUE_CONFIGURATION, options));
     }
@@ -272,7 +281,7 @@ class BunnyBus extends EventEmitter{
 
         let result = false;
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
         const promise = new Promise((resolve) => {
 
@@ -302,7 +311,7 @@ class BunnyBus extends EventEmitter{
             }
         }
         finally {
-            await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
         }
 
         return result;
@@ -310,7 +319,7 @@ class BunnyBus extends EventEmitter{
 
     async deleteQueue(name, options) {
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
         return await channelContext.channel.deleteQueue(name, options);
     }
@@ -319,7 +328,7 @@ class BunnyBus extends EventEmitter{
 
         let result = undefined;
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
         const promise = new Promise((resolve) => {
 
@@ -348,7 +357,7 @@ class BunnyBus extends EventEmitter{
             }
         }
         finally {
-            await $._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
         }
 
         return result;
@@ -364,8 +373,8 @@ class BunnyBus extends EventEmitter{
             ? options.transactionId
             : Helpers.createTransactionId();
         const [channelContext] = await Promise.all([
-            $._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue), queue),
-            $.createQueue(queue)
+            this._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue), queue),
+            this.createQueue(queue)
         ]);
 
         const headers = {
@@ -385,7 +394,7 @@ class BunnyBus extends EventEmitter{
 
     async get(queue, options) {
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue), queue);
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue), queue);
 
         return await channelContext.channel.get(queue, options);
     }
@@ -399,7 +408,7 @@ class BunnyBus extends EventEmitter{
         let processing = true;
 
         do {
-            const payload = await $.get(queue, getOptions);
+            const payload = await this.get(queue, getOptions);
 
             if (payload) {
                 const parsedPayload = Helpers.parsePayload(payload);
@@ -408,13 +417,13 @@ class BunnyBus extends EventEmitter{
                     await handler(
                         parsedPayload.message,
                         parsedPayload.metaData,
-                        $._ack.bind(null, payload, channelName)
+                        this._ack.bind(this, payload, channelName)
                     );
                 }
                 else {
                     await handler(
                         parsedPayload.message,
-                        $._ack.bind(null, payload, channelName)
+                        this._ack.bind(this, payload, channelName)
                     );
                 }
             }
@@ -426,7 +435,7 @@ class BunnyBus extends EventEmitter{
 
     async publish(message, options) {
 
-        const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
+        const globalExchange = (options && options.globalExchange) || this.config.globalExchange;
         const routeKey = Helpers.reduceRouteKey(null, options, message);
         const source = (options && options.source);
 
@@ -439,8 +448,8 @@ class BunnyBus extends EventEmitter{
             ? options.transactionId
             : Helpers.createTransactionId();
         const [channelContext] = await Promise.all([
-            $._autoBuildChannelContext(BunnyBus.PUBLISH_CHANNEL_NAME()),
-            $.createExchange(globalExchange, 'topic', null)
+            this._autoBuildChannelContext(BunnyBus.PUBLISH_CHANNEL_NAME()),
+            this.createExchange(globalExchange, 'topic', null)
         ]);
 
         const headers = {
@@ -457,38 +466,36 @@ class BunnyBus extends EventEmitter{
         await channelContext.channel.publish(globalExchange, routeKey, convertedMessage.buffer, publishOptions);
         await channelContext.channel.waitForConfirms();
 
-        $.emit(BunnyBus.PUBLISHED_EVENT, publishOptions, message);
+        this.emit(BunnyBus.PUBLISHED_EVENT, publishOptions, message);
     }
 
     async subscribe(queue, handlers, options) {
 
-        const $S = $.subscriptions;
-
-        if ($S.contains(queue)) {
+        if (this.subscriptions.contains(queue)) {
             throw new Exceptions.SubscriptionExistError(queue);
         }
 
-        if ($S.isBlocked(queue)) {
+        if (this.subscriptions.isBlocked(queue)) {
             throw new Exceptions.SubscriptionBlockedError(queue);
         }
 
-        $S.create(queue, handlers, options);
+        this.subscriptions.create(queue, handlers, options);
 
         const queueOptions = options && options.queue ? options.queue : null;
-        const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
-        const maxRetryCount = (options && options.maxRetryCount) || $.config.maxRetryCount;
-        const validatePublisher = (options && options.hasOwnProperty('validatePublisher')) ? options.validatePublisher : $.config.validatePublisher;
-        const validateVersion = (options && options.hasOwnProperty('validateVersion')) ? options.validateVersion : $.config.validateVersion;
-        const disableQueueBind = (options && options.hasOwnProperty('disableQueueBind')) ? options.disableQueueBind : $.config.disableQueueBind;
-        const rejectUnroutedMessages = (options && options.hasOwnProperty('rejectUnroutedMessages')) ? options.rejectUnroutedMessages : $.config.rejectUnroutedMessages;
+        const globalExchange = (options && options.globalExchange) || this.config.globalExchange;
+        const maxRetryCount = (options && options.maxRetryCount) || this.config.maxRetryCount;
+        const validatePublisher = (options && options.hasOwnProperty('validatePublisher')) ? options.validatePublisher : this.config.validatePublisher;
+        const validateVersion = (options && options.hasOwnProperty('validateVersion')) ? options.validateVersion : this.config.validateVersion;
+        const disableQueueBind = (options && options.hasOwnProperty('disableQueueBind')) ? options.disableQueueBind : this.config.disableQueueBind;
+        const rejectUnroutedMessages = (options && options.hasOwnProperty('rejectUnroutedMessages')) ? options.rejectUnroutedMessages : this.config.rejectUnroutedMessages;
         const meta = (options && options.meta);
         const channelName = BunnyBus.QUEUE_CHANNEL_NAME(queue);
 
-        const channelContext = await $._autoBuildChannelContext(channelName, queue);
+        const channelContext = await this._autoBuildChannelContext(channelName, queue);
 
         await Promise.all([
-            $.createQueue(queue, queueOptions),
-            $.createExchange(globalExchange, 'topic', null)
+            this.createQueue(queue, queueOptions),
+            this.createExchange(globalExchange, 'topic', null)
         ]);
 
         if (!disableQueueBind) {
@@ -510,38 +517,38 @@ class BunnyBus extends EventEmitter{
                         // check for `bunnyBus` header first
                         if (validatePublisher && !(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)) {
                             const reason = 'message not of BunnyBus origin';
-                            $.logger.warn(reason);
-                            await $._reject(payload, channelName, errorQueue, { reason });
+                            this.logger.warn(reason);
+                            await this._reject(payload, channelName, errorQueue, { reason });
                         }
                         // check for `bunnyBus`:<version> semver
                         else if (validatePublisher && validateVersion && !Helpers.isMajorCompatible(payload.properties.headers.bunnyBus)) {
                             const reason = `message came from older bunnyBus version (${payload.properties.headers.bunnyBus})`;
-                            $.logger.warn(reason);
-                            await $._reject(payload, channelName, errorQueue, { reason });
+                            this.logger.warn(reason);
+                            await this._reject(payload, channelName, errorQueue, { reason });
                         }
                         else if (currentRetryCount < maxRetryCount) {
                             matchedHandlers.forEach(async (matchedHandler) => {
 
-                                $._dispatchers[$.config.dispatchType].push(
+                                this._dispatchers[this.config.dispatchType].push(
                                     queue,
                                     async () => {
 
-                                        $.emit(BunnyBus.MESSAGE_DISPATCHED_EVENT, parsedPayload.metaData, parsedPayload.message);
+                                        this.emit(BunnyBus.MESSAGE_DISPATCHED_EVENT, parsedPayload.metaData, parsedPayload.message);
                                         if (meta) {
                                             await matchedHandler(
                                                 parsedPayload.message,
                                                 parsedPayload.metaData,
-                                                $._ack.bind(null, payload, channelName),
-                                                $._reject.bind(null, payload, channelName, errorQueue),
-                                                $._requeue.bind(null, payload, channelName, queue, { routeKey })
+                                                this._ack.bind(this, payload, channelName),
+                                                this._reject.bind(this, payload, channelName, errorQueue),
+                                                this._requeue.bind(this, payload, channelName, queue, { routeKey })
                                             );
                                         }
                                         else {
                                             await matchedHandler(
                                                 parsedPayload.message,
-                                                $._ack.bind(null, payload, channelName),
-                                                $._reject.bind(null, payload, channelName, errorQueue),
-                                                $._requeue.bind(null, payload, channelName, queue)
+                                                this._ack.bind(this, payload, channelName),
+                                                this._reject.bind(this, payload, channelName, errorQueue),
+                                                this._requeue.bind(this, payload, channelName, queue)
                                             );
                                         }
                                     }
@@ -550,15 +557,15 @@ class BunnyBus extends EventEmitter{
                         }
                         else {
                             const reason = `message passed retry limit of ${maxRetryCount} for routeKey (${routeKey})`;
-                            $.logger.warn(reason);
-                            await $._reject(payload, channelName, errorQueue, { reason });
+                            this.logger.warn(reason);
+                            await this._reject(payload, channelName, errorQueue, { reason });
                         }
                     }
                     else {
                         const reason = `message consumed with no matching routeKey (${routeKey}) handler`;
-                        $.logger.warn(reason);
+                        this.logger.warn(reason);
                         if (rejectUnroutedMessages) {
-                            await $._reject(payload, channelName, errorQueue, { reason });
+                            await this._reject(payload, channelName, errorQueue, { reason });
                         }
                         else {
                             // acking this directly to channel so events don't fire
@@ -570,40 +577,38 @@ class BunnyBus extends EventEmitter{
         );
 
         if (result && result.consumerTag) {
-            $S.tag(queue, result.consumerTag);
-            $.emit(BunnyBus.SUBSCRIBED_EVENT, queue);
+            this.subscriptions.tag(queue, result.consumerTag);
+            this.emit(BunnyBus.SUBSCRIBED_EVENT, queue);
         }
     }
 
     async unsubscribe(queue) {
 
-        const channelContext = await $._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue));
+        const channelContext = await this._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue));
 
-        const $S = $.subscriptions;
-
-        if ($S.contains(queue)) {
-            await channelContext.channel.cancel($S.get(queue).consumerTag);
-            $S.clear(queue);
-            $.emit(BunnyBus.UNSUBSCRIBED_EVENT, queue);
+        if (this.subscriptions.contains(queue)) {
+            await channelContext.channel.cancel(this.subscriptions.get(queue).consumerTag);
+            this.subscriptions.clear(queue);
+            this.emit(BunnyBus.UNSUBSCRIBED_EVENT, queue);
         }
     }
 
     //options to store calling module, queue name
     async _ack(payload, channelName, options) {
 
-        const channelContext = await $._autoBuildChannelContext(channelName);
+        const channelContext = await this._autoBuildChannelContext(channelName);
 
         await channelContext.channel.ack(payload);
 
         const parsedPayload = Helpers.parsePayload(payload);
         parsedPayload.metaData.headers.ackedAt = (new Date()).toISOString();
 
-        $.emit(BunnyBus.MESSAGE_ACKED_EVENT, parsedPayload.metaData, parsedPayload.message);
+        this.emit(BunnyBus.MESSAGE_ACKED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }
 
     async _requeue(payload, channelName, queue, options) {
 
-        const channelContext = await $._autoBuildChannelContext(channelName);
+        const channelContext = await this._autoBuildChannelContext(channelName);
 
         const routeKey = Helpers.reduceRouteKey(payload, options);
 
@@ -628,14 +633,14 @@ class BunnyBus extends EventEmitter{
         const parsedPayload = Helpers.parsePayload(payload);
         parsedPayload.metaData.headers = Object.assign(parsedPayload.metaData.headers, headers);
 
-        $.emit(BunnyBus.MESSAGE_REQUEUED_EVENT, parsedPayload.metaData, parsedPayload.message);
+        this.emit(BunnyBus.MESSAGE_REQUEUED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }
 
     async _reject(payload, channelName, errorQueue, options) {
 
-        const channelContext = await $._autoBuildChannelContext(channelName);
+        const channelContext = await this._autoBuildChannelContext(channelName);
 
-        const queue = errorQueue || $.config.server.errorQueue;
+        const queue = errorQueue || this.config.server.errorQueue;
 
         const headers = {
             transactionId : payload.properties.headers.transactionId,
@@ -651,7 +656,7 @@ class BunnyBus extends EventEmitter{
 
         const sendOptions = Helpers.buildPublishOrSendOptions(options, headers);
 
-        await $.createQueue(queue);
+        await this.createQueue(queue);
         await channelContext.channel.sendToQueue(queue, payload.content, sendOptions);
         await channelContext.channel.waitForConfirms();
         await channelContext.channel.ack(payload);
@@ -659,13 +664,13 @@ class BunnyBus extends EventEmitter{
         const parsedPayload = Helpers.parsePayload(payload);
         parsedPayload.metaData.headers = Object.assign(parsedPayload.metaData.headers, headers);
 
-        $.emit(BunnyBus.MESSAGE_REJECTED_EVENT, parsedPayload.metaData, parsedPayload.message);
+        this.emit(BunnyBus.MESSAGE_REJECTED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }
 
     async _autoBuildChannelContext(channelName, queue = null) {
 
         let connectionContext = undefined;
-        let channelContext = $.channels.get(channelName);
+        let channelContext = this.channels.get(channelName);
 
         if (channelContext && channelContext.channel && channelContext.connectionContext.connection) {
             return channelContext;
@@ -674,87 +679,87 @@ class BunnyBus extends EventEmitter{
         const addListener = (subject, eventName, handler) => {
 
             const key = `${subject.uniqueName}_${eventName}`;
-            if (!$._handlerAssignmentLedger.has(key)) {
-                $._handlerAssignmentLedger.set(key, handler);
+            if (!this._handlerAssignmentLedger.has(key)) {
+                this._handlerAssignmentLedger.set(key, handler);
                 subject.on(eventName, handler);
             }
         };
 
-        connectionContext = await $.connections.create(BunnyBus.DEFAULT_CONNECTION_NAME, $.config);
-        addListener(connectionContext, ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT, $._on_connectionManager_AMQP_CONNECTION_CLOSE_EVENT.bind($));
-        addListener(connectionContext, ConnectionManager.AMQP_CONNECTION_ERROR_EVENT, $._on_connectionManager_AMQP_CONNECTION_ERROR_EVENT.bind($));
+        connectionContext = await this.connections.create(BunnyBus.DEFAULT_CONNECTION_NAME, this.config);
+        addListener(connectionContext, ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT, this._on_connectionManager_AMQP_CONNECTION_CLOSE_EVENT.bind(this));
+        addListener(connectionContext, ConnectionManager.AMQP_CONNECTION_ERROR_EVENT, this._on_connectionManager_AMQP_CONNECTION_ERROR_EVENT.bind(this));
 
-        channelContext = await $.channels.create(channelName, queue, connectionContext, $.config);
-        addListener(channelContext, ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, $._on_channelManager_AMQP_CHANNEL_CLOSE_EVENT.bind($));
-        addListener(channelContext, ChannelManager.AMQP_CHANNEL_ERROR_EVENT, $._on_channelManager_AMQP_CHANNEL_ERROR_EVENT.bind($));
+        channelContext = await this.channels.create(channelName, queue, connectionContext, this.config);
+        addListener(channelContext, ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, this._on_channelManager_AMQP_CHANNEL_CLOSE_EVENT.bind(this));
+        addListener(channelContext, ChannelManager.AMQP_CHANNEL_ERROR_EVENT, this._on_channelManager_AMQP_CHANNEL_ERROR_EVENT.bind(this));
 
         return channelContext;
     }
 
     async _recoverConnection() {
 
-        for (const { name, queue } of $.channels.list()) {
+        for (const { name, queue } of this.channels.list()) {
             if (queue) {
-                await $._recoverChannel(name);
+                await this._recoverChannel(name);
             }
         }
     }
 
     async _recoverChannel(channelName) {
 
-        if (!$._state.recoveryLock) {
+        if (!this._state.recoveryLock) {
 
-            $._state.recoveryLock = true;
+            this._state.recoveryLock = true;
 
             try {
-                const { queue } = $.channels.get(channelName);
+                const { queue } = this.channels.get(channelName);
 
-                if (queue && $.subscriptions.contains(queue, false)) {
-                    const { handlers, options } = $.subscriptions.get(queue);
+                if (queue && this.subscriptions.contains(queue, false)) {
+                    const { handlers, options } = this.subscriptions.get(queue);
 
-                    if (!$.subscriptions.isBlocked(queue)) {
-                        $.subscriptions.clear(queue);
-                        await $.subscribe(queue, handlers, options);
+                    if (!this.subscriptions.isBlocked(queue)) {
+                        this.subscriptions.clear(queue);
+                        await this.subscribe(queue, handlers, options);
                     }
                 }
             }
             catch (err) {
                 err.bunnyBusMessage = 'failed to recover, exiting process';
-                $.logger.fatal(err);
-                $.emit(BunnyBus.RECOVERY_FAILED_EVENT, err);
+                this.logger.fatal(err);
+                this.emit(BunnyBus.RECOVERY_FAILED_EVENT, err);
                 throw err;
             }
             finally {
-                $._state.recoveryLock = false;
+                this._state.recoveryLock = false;
             }
         }
     }
 
     async _on_subscriptionManager_BLOCKED_EVENT(queue) {
 
-        $.logger.info(`blocking queue ${queue}`);
+        this.logger.info(`blocking queue ${queue}`);
 
         try {
-            await $.unsubscribe(queue);
+            await this.unsubscribe(queue);
         }
         catch (err) {
             err.bunnyBusMessage = 'blocked event handling failed';
-            $.logger.error(err);
+            this.logger.error(err);
         }
     }
 
     async _on_subscriptionManager_UNBLOCKED_EVENT(queue) {
 
-        const subscription = $._subscriptions.get(queue);
+        const subscription = this._subscriptions.get(queue);
 
-        $.logger.info(`unblocking queue ${queue}`);
+        this.logger.info(`unblocking queue ${queue}`);
 
         try {
-            await $.subscribe(queue, subscription.handlers, subscription.options);
+            await this.subscribe(queue, subscription.handlers, subscription.options);
         }
         catch (err) {
             err.bunnyBusMessage = 'unblocked event handling failed';
-            $.logger.error(err);
+            this.logger.error(err);
         }
     }
 
@@ -762,17 +767,17 @@ class BunnyBus extends EventEmitter{
 
         err.bunnyBusMessage = 'connection error';
         err.context = context;
-        $.logger.error(err);
+        this.logger.error(err);
     }
 
     async _on_connectionManager_AMQP_CONNECTION_CLOSE_EVENT(context) {
 
-        $.logger.info(`${context.name} connection closed`);
+        this.logger.info(`${context.name} connection closed`);
 
         try {
-            $.emit(BunnyBus.RECOVERING_CONNECTION_EVENT, context.name);
-            await $._recoverConnection();
-            $.emit(BunnyBus.RECOVERED_CONNECTION_EVENT, context.name);
+            this.emit(BunnyBus.RECOVERING_CONNECTION_EVENT, context.name);
+            await this._recoverConnection();
+            this.emit(BunnyBus.RECOVERED_CONNECTION_EVENT, context.name);
         }
         catch (err) {}
     }
@@ -781,17 +786,17 @@ class BunnyBus extends EventEmitter{
 
         err.bunnyBusMessage = 'channel errored';
         err.context = context;
-        $.logger.error(err);
+        this.logger.error(err);
     }
 
     async _on_channelManager_AMQP_CHANNEL_CLOSE_EVENT(context) {
 
-        $.logger.info(`${context.name} channel closed`);
+        this.logger.info(`${context.name} channel closed`);
 
         try {
-            $.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);
-            await $._recoverChannel(context.name);
-            $.emit(BunnyBus.RECOVERED_CHANNEL_EVENT, context.name);
+            this.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);
+            await this._recoverChannel(context.name);
+            this.emit(BunnyBus.RECOVERED_CHANNEL_EVENT, context.name);
         }
         catch (err) {}
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,10 +7,6 @@ const { ChannelManager, ConnectionManager, SubscriptionManager } = require('./st
 const { SerialDispatcher, ConcurrentDispatcher } = require('./schedulers');
 const { EventLogger } = require('./loggers');
 
-const internals = {
-    handlers : {}
-};
-
 let $ = undefined;
 
 class BunnyBus extends EventEmitter{
@@ -34,9 +30,10 @@ class BunnyBus extends EventEmitter{
                 serial: new SerialDispatcher(),
                 concurrent: new ConcurrentDispatcher()
             };
+            $._handlerAssignmentLedger = new Map();
 
-            $._subscriptions.on(SubscriptionManager.BLOCKED_EVENT, internals.handlers[SubscriptionManager.BLOCKED_EVENT]);
-            $._subscriptions.on(SubscriptionManager.UNBLOCKED_EVENT, internals.handlers[SubscriptionManager.UNBLOCKED_EVENT]);
+            $._subscriptions.on(SubscriptionManager.BLOCKED_EVENT, $._on_subscriptionManager_BLOCKED_EVENT.bind($));
+            $._subscriptions.on(SubscriptionManager.UNBLOCKED_EVENT, $._on_subscriptionManager_UNBLOCKED_EVENT.bind($));
         }
 
         if (config) {
@@ -674,18 +671,22 @@ class BunnyBus extends EventEmitter{
             return channelContext;
         }
 
+        const addListener = (subject, eventName, handler) => {
+
+            const key = `${subject.uniqueName}_${eventName}`;
+            if (!$._handlerAssignmentLedger.has(key)) {
+                $._handlerAssignmentLedger.set(key, handler);
+                subject.on(eventName, handler);
+            }
+        };
+
         connectionContext = await $.connections.create(BunnyBus.DEFAULT_CONNECTION_NAME, $.config);
-        connectionContext
-            .removeListener(ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT, internals.handlers[ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT])
-            .on(ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT, internals.handlers[ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT])
-            .removeListener(ConnectionManager.AMQP_CONNECTION_ERROR_EVENT, internals.handlers[ConnectionManager.AMQP_CONNECTION_ERROR_EVENT])
-            .on(ConnectionManager.AMQP_CONNECTION_ERROR_EVENT, internals.handlers[ConnectionManager.AMQP_CONNECTION_ERROR_EVENT]);
+        addListener(connectionContext, ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT, $._on_connectionManager_AMQP_CONNECTION_CLOSE_EVENT.bind($));
+        addListener(connectionContext, ConnectionManager.AMQP_CONNECTION_ERROR_EVENT, $._on_connectionManager_AMQP_CONNECTION_ERROR_EVENT.bind($));
+
         channelContext = await $.channels.create(channelName, queue, connectionContext, $.config);
-        channelContext
-            .removeListener(ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, internals.handlers[ChannelManager.AMQP_CHANNEL_CLOSE_EVENT])
-            .on(ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, internals.handlers[ChannelManager.AMQP_CHANNEL_CLOSE_EVENT])
-            .removeListener(ChannelManager.AMQP_CHANNEL_ERROR_EVENT, internals.handlers[ChannelManager.AMQP_CHANNEL_ERROR_EVENT])
-            .on(ChannelManager.AMQP_CHANNEL_ERROR_EVENT, internals.handlers[ChannelManager.AMQP_CHANNEL_ERROR_EVENT]);
+        addListener(channelContext, ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, $._on_channelManager_AMQP_CHANNEL_CLOSE_EVENT.bind($));
+        addListener(channelContext, ChannelManager.AMQP_CHANNEL_ERROR_EVENT, $._on_channelManager_AMQP_CHANNEL_ERROR_EVENT.bind($));
 
         return channelContext;
     }
@@ -728,72 +729,72 @@ class BunnyBus extends EventEmitter{
             }
         }
     }
+
+    async _on_subscriptionManager_BLOCKED_EVENT(queue) {
+
+        $.logger.info(`blocking queue ${queue}`);
+
+        try {
+            await $.unsubscribe(queue);
+        }
+        catch (err) {
+            err.bunnyBusMessage = 'blocked event handling failed';
+            $.logger.error(err);
+        }
+    }
+
+    async _on_subscriptionManager_UNBLOCKED_EVENT(queue) {
+
+        const subscription = $._subscriptions.get(queue);
+
+        $.logger.info(`unblocking queue ${queue}`);
+
+        try {
+            await $.subscribe(queue, subscription.handlers, subscription.options);
+        }
+        catch (err) {
+            err.bunnyBusMessage = 'unblocked event handling failed';
+            $.logger.error(err);
+        }
+    }
+
+    _on_connectionManager_AMQP_CONNECTION_ERROR_EVENT(err, context) {
+
+        err.bunnyBusMessage = 'connection error';
+        err.context = context;
+        $.logger.error(err);
+    }
+
+    async _on_connectionManager_AMQP_CONNECTION_CLOSE_EVENT(context) {
+
+        $.logger.info(`${context.name} connection closed`);
+
+        try {
+            $.emit(BunnyBus.RECOVERING_CONNECTION_EVENT, context.name);
+            await $._recoverConnection();
+            $.emit(BunnyBus.RECOVERED_CONNECTION_EVENT, context.name);
+        }
+        catch (err) {}
+    }
+
+    _on_channelManager_AMQP_CHANNEL_ERROR_EVENT(err, context) {
+
+        err.bunnyBusMessage = 'channel errored';
+        err.context = context;
+        $.logger.error(err);
+    }
+
+    async _on_channelManager_AMQP_CHANNEL_CLOSE_EVENT(context) {
+
+        $.logger.info(`${context.name} channel closed`);
+
+        try {
+            $.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);
+            await $._recoverChannel(context.name);
+            $.emit(BunnyBus.RECOVERED_CHANNEL_EVENT, context.name);
+        }
+        catch (err) {}
+    }
 }
-
-internals.handlers[SubscriptionManager.BLOCKED_EVENT] = async (queue) => {
-
-    $.logger.info(`blocking queue ${queue}`);
-
-    try {
-        await $.unsubscribe(queue);
-    }
-    catch (err) {
-        err.bunnyBusMessage = 'blocked event handling failed';
-        $.logger.error(err);
-    }
-};
-
-internals.handlers[SubscriptionManager.UNBLOCKED_EVENT] = async (queue) => {
-
-    const subscription = $._subscriptions.get(queue);
-
-    $.logger.info(`unblocking queue ${queue}`);
-
-    try {
-        await $.subscribe(queue, subscription.handlers, subscription.options);
-    }
-    catch (err) {
-        err.bunnyBusMessage = 'unblocked event handling failed';
-        $.logger.error(err);
-    }
-};
-
-internals.handlers[ConnectionManager.AMQP_CONNECTION_ERROR_EVENT] = (err, context) => {
-
-    err.bunnyBusMessage = 'connection error';
-    err.context = context;
-    $.logger.error(err);
-};
-
-internals.handlers[ConnectionManager.AMQP_CONNECTION_CLOSE_EVENT] = async (context) => {
-
-    $.logger.info(`${context.name} connection closed`);
-
-    try {
-        $.emit(BunnyBus.RECOVERING_CONNECTION_EVENT, context.name);
-        await $._recoverConnection();
-        $.emit(BunnyBus.RECOVERED_CONNECTION_EVENT, context.name);
-    }
-    catch (err) {}
-};
-
-internals.handlers[ChannelManager.AMQP_CHANNEL_ERROR_EVENT] = (err, context) => {
-
-    err.bunnyBusMessage = 'channel errored';
-    err.context = context;
-    $.logger.error(err);
-};
-
-internals.handlers[ChannelManager.AMQP_CHANNEL_CLOSE_EVENT] = async (context) => {
-
-    $.logger.info(`${context.name} channel closed`);
-
-    try {
-        $.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);
-        await $._recoverChannel(context.name);
-        $.emit(BunnyBus.RECOVERED_CHANNEL_EVENT, context.name);
-    }
-    catch (err) {}
-};
 
 module.exports = BunnyBus;

--- a/lib/states/channelManager.js
+++ b/lib/states/channelManager.js
@@ -11,6 +11,7 @@ class Channel extends EventEmitter {
 
         super();
 
+        this._createdAt = Date.now();
         this._name = name;
         this._queue = queue;
         this._connectionContext = connectionContext;
@@ -22,6 +23,11 @@ class Channel extends EventEmitter {
     get name() {
 
         return this._name;
+    }
+
+    get uniqueName() {
+
+        return `channel_${this._name}_${this._createdAt}`;
     }
 
     get queue() {

--- a/lib/states/connectionManager.js
+++ b/lib/states/connectionManager.js
@@ -10,6 +10,7 @@ class Connection extends EventEmitter {
 
         super();
 
+        this._createdAt = Date.now();
         this._name = name;
         this._connectionOptions = connectionOptions;
         this._socketOptions = socketOptions;
@@ -23,6 +24,11 @@ class Connection extends EventEmitter {
     get name() {
 
         return this._name;
+    }
+
+    get uniqueName() {
+
+        return `connection_${this._name}_${this._createdAt}`;
     }
 
     get connectionOptions() {

--- a/test/BunnyBus/singleton.js
+++ b/test/BunnyBus/singleton.js
@@ -11,16 +11,27 @@ describe('singleton', () => {
 
     it('should generate an instance of BunnyBus', () => {
 
-        const instance = new BunnyBus();
+        const instance = BunnyBus.Singleton();
 
         expect(instance).to.be.an.instanceof(BunnyBus);
     });
 
     it('should generate the same instance when instantiated twice', () => {
 
-        const instance1 = new BunnyBus();
-        const instance2 = new BunnyBus();
+        const instance1 = BunnyBus.Singleton();
+        const instance2 = BunnyBus.Singleton();
 
         expect(instance1).to.shallow.equal(instance2);
+    });
+
+    it('should not be the same as a non-singleton instance', () => {
+
+        const instance1 = BunnyBus.Singleton();
+        const instance2 = BunnyBus.Singleton();
+
+        const nonSingletonInstance = new BunnyBus();
+
+        expect(instance1).to.shallow.equal(instance2);
+        expect(nonSingletonInstance).to.not.shallow.equal(instance1);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A big change that makes singleton instantiation optional.  The default `new BunnyBus()` constructor returns a new instance every time now.  To access a singleton, you use the static method presented here `BunnyBus.Singleton(config)`. 

A bug was found related to event handler attachments to the connection object.  This bug presented itself as a memory leak.  We now keep an event handler ledge to keep track of events that has been delegated.

## Motivation and Context
The changes here was spurred by the desire to create a centralized configuration model for Hapi's plugin ecosystem we have here at Tenna.  We design a Hapi plugin to drive the consumer mechanism for processing things off a queue.  Each plugin/consumer uses the same base RMQ configurations.  We want a single input method for providing these settings to all the plugins.  At the same time, each of these plugins need to have different instance to maintain proper state of meta information like logging attributes.  In the future, each plugin could also be responsible for its own connection to get faster performance with the Rabbit server.

## Note
This is not a backwards compatible change due to the removal of default singleton instantiation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.