### PR TITLE
Extending publish options and finer grain control of RMQ resources

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,12 +6,11 @@
         "@hapi/eslint-plugin-hapi"
     ],
     "rules": {
-        "consistent-this" : [ 0, "self", "$" ],
         "require-await": "off",
         "no-unused-vars": "off",
         "quote-props": [ "error", "consistent-as-needed", { "unnecessary" : true, "numbers" : true }]
     },
     "parserOptions": {
-        "ecmaVersion": 8
+        "ecmaVersion": 2018
     }
 }

--- a/API.md
+++ b/API.md
@@ -505,7 +505,7 @@ Publish a message onto the bus.
     - `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]* **Optional**
     - `source` - value attached to the header of the message to help with track the origin of messages in your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]* **Optional**
     - `globalExchange` - value to override the exchange specified in [`config`](#config). *[string]* **Optional**
-    - `header` - object used to overlay into the message request header (`payload.properties.headers`).  *[Object]* **Optional**
+    - `headers` - object used to overlay into the message request header (`payload.properties.headers`).  *[Object]* **Optional**
     - In addition to the above options, all of `amqplib`'s [configuration options](http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish) (except for `headers` and `immediate`) from its `sendToQueue` and `publish` methods can also be passed as top-level properties in the `publish` options.
 
 ```javascript

--- a/API.md
+++ b/API.md
@@ -275,6 +275,8 @@ Setter and Getter for configuration. Accepts the following optional properties:
  * `validatePublisher` - flag to dictate if the publishing source for messages being consumed must be `bunnyBus`.  This is a safe guard to prevent unexpected message sources from entering the subscribing realm. A value of `bunnyBus` is stamped as a header property on the message during `publish()`.  The `subscribe()` method will use the same value for authentication.  Consumers detecting mismatched publishers will auto reject the message into an error queue.  Defaults to `false`. *[boolean]* **Optional**
  * `validateVersion` - flag to dictate if major semver should be matched as part of the message subscription valiation.  This is a safe guard to prevent mismatched `bunnyBus` drivers from pub/sub to each other.  Consumers detecting mismatched major values will auto reject the message into an error queue.  In order for this layer of validation to occur, `validatePublisher` must be allowed because the version value is set against the `bunnyBus` header.   Defaults to `false`. *[boolean]* **Optional**
  * `disableQueueBind` - flag to dictate if automatic queue binding should be turned on/off as part of the consume setup process.  Defaults to `false`.  *[boolean]* **Optional**
+ * `disableQueueCreate` - flag to dictate if automatic queue creation should be turned on/off.  Defaults to `false`.  *[boolean]* **Optional**
+* `disableExchangeCreate` - flag to dictate if automatic exchange creation should be turned on/off.  Defaults to `false`.  *[boolean]* **Optional**
  * `dispatchType` - enumerated value to select dispatch mechanism used.  `serial` will flow messages to your message handler(s) in single file.  `concurrent` will flow messages simultaneously to your message handler(s).  Defaults to `serial`.  *[string]* **Optional**
  * `rejectUnroutedMessages` - flag to direct messages that were unroutable to provided handlers to either be automatically rejected or acknowledged off the queue.  The default is silent acknowledgements.  Defaults to `false`.  *[boolean]* **Optional**
 
@@ -503,6 +505,7 @@ Publish a message onto the bus.
     - `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]* **Optional**
     - `source` - value attached to the header of the message to help with track the origin of messages in your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]* **Optional**
     - `globalExchange` - value to override the exchange specified in [`config`](#config). *[string]* **Optional**
+    - `header` - object used to overlay into the message request header (`payload.properties.headers`).  *[Object]* **Optional**
     - In addition to the above options, all of `amqplib`'s [configuration options](http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish) (except for `headers` and `immediate`) from its `sendToQueue` and `publish` methods can also be passed as top-level properties in the `publish` options.
 
 ```javascript

--- a/lib/helpers/defaultConfiguration.js
+++ b/lib/helpers/defaultConfiguration.js
@@ -21,7 +21,9 @@ module.exports = {
         validateVersion         : false,
         dispatchType            : 'serial',
         rejectUnroutedMessages  : false,
-        disableQueueBind        : false
+        disableQueueBind        : false,
+        disableQueueCreate      : false,
+        disableExchangeCreate   : false
     },
     queue : {
         exclusive : false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -438,6 +438,7 @@ class BunnyBus extends EventEmitter{
         const globalExchange = (options && options.globalExchange) || this.config.globalExchange;
         const routeKey = Helpers.reduceRouteKey(null, options, message);
         const source = (options && options.source);
+        const headerOptions = (options && options.header) || {};
 
         if (!routeKey) {
             throw new Exceptions.NoRouteKeyError();
@@ -458,7 +459,8 @@ class BunnyBus extends EventEmitter{
             source,
             routeKey,
             createdAt: (new Date()).toISOString(),
-            bunnyBus: Helpers.getPackageData().version
+            bunnyBus: Helpers.getPackageData().version,
+            ...headerOptions
         };
 
         const publishOptions = Helpers.buildPublishOrSendOptions(options, headers);

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,9 +272,11 @@ class BunnyBus extends EventEmitter{
 
     async createQueue(name, options) {
 
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
-
-        return await channelContext.channel.assertQueue(name, Object.assign({}, BunnyBus.DEFAULT_QUEUE_CONFIGURATION, options));
+        if (!this.config.disableQueueCreate) {
+            const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+    
+            return await channelContext.channel.assertQueue(name, Object.assign({}, BunnyBus.DEFAULT_QUEUE_CONFIGURATION, options));
+        }
     }
 
     async purgeQueue(name) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -442,7 +442,7 @@ class BunnyBus extends EventEmitter{
         const globalExchange = (options && options.globalExchange) || this.config.globalExchange;
         const routeKey = Helpers.reduceRouteKey(null, options, message);
         const source = (options && options.source);
-        const headerOptions = (options && options.header) || {};
+        const headerOptions = (options && options.headers) || {};
 
         if (!routeKey) {
             throw new Exceptions.NoRouteKeyError();

--- a/lib/index.js
+++ b/lib/index.js
@@ -218,10 +218,12 @@ class BunnyBus extends EventEmitter{
 
     async createExchange(name, type, options) {
 
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
-
-        //type : (direct, fanout, header, topic)
-        return await channelContext.channel.assertExchange(name, type, Object.assign({}, BunnyBus.DEFAULT_EXCHANGE_CONFIGURATION, options));
+        if (!this.config.disableExchangeCreate) {
+            const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+    
+            //type : (direct, fanout, header, topic)
+            return await channelContext.channel.assertExchange(name, type, Object.assign({}, BunnyBus.DEFAULT_EXCHANGE_CONFIGURATION, options));
+        }
     }
 
     async deleteExchange(name, options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,7 +220,7 @@ class BunnyBus extends EventEmitter{
 
         if (!this.config.disableExchangeCreate) {
             const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
-    
+
             //type : (direct, fanout, header, topic)
             return await channelContext.channel.assertExchange(name, type, Object.assign({}, BunnyBus.DEFAULT_EXCHANGE_CONFIGURATION, options));
         }
@@ -276,7 +276,7 @@ class BunnyBus extends EventEmitter{
 
         if (!this.config.disableQueueCreate) {
             const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
-    
+
             return await channelContext.channel.assertQueue(name, Object.assign({}, BunnyBus.DEFAULT_QUEUE_CONFIGURATION, options));
         }
     }

--- a/test/BunnyBus/createExchange.js
+++ b/test/BunnyBus/createExchange.js
@@ -166,6 +166,31 @@ describe('BunnyBus', () => {
                 channelContext,
                 channelManager);
             });
+
+            it('should not create an exchange when disableExchangeCreate === true', async () => {
+
+                instance.config = { disableExchangeCreate: true };
+
+                await Assertions.autoRecoverChannel(async () => {
+
+                    let result1 = null;
+
+                    const result2 = await instance.createExchange(baseExchangeName, 'topic');
+
+                    try {
+                        await channelContext.channel.checkExchange(baseExchangeName);
+                    }
+                    catch (err) {
+                        result1 = err;
+                    }
+
+                    expect(result1).to.exist();
+                    expect(result2).to.be.undefined();
+                },
+                connectionContext,
+                channelContext,
+                channelManager);
+            });
         });
     });
 });

--- a/test/BunnyBus/createQueue.js
+++ b/test/BunnyBus/createQueue.js
@@ -185,8 +185,8 @@ describe('BunnyBus', () => {
                         result1 = err;
                     }
 
-                    expect(result2).to.be.undefined();
                     expect(result1).to.exist();
+                    expect(result2).to.be.undefined();
                 },
                 connectionContext,
                 channelContext,

--- a/test/BunnyBus/createQueue.js
+++ b/test/BunnyBus/createQueue.js
@@ -167,6 +167,31 @@ describe('BunnyBus', () => {
                 channelContext,
                 channelManager);
             });
+
+            it('should not create a queue when disableQueueCreate === true', async () => {
+
+                instance.config = { disableQueueCreate: true };
+
+                await Assertions.autoRecoverChannel(async () => {
+
+                    let result1 = null;
+
+                    const result2 = await instance.createQueue(baseQueueName);
+
+                    try {
+                        await channelContext.channel.checkQueue(baseQueueName);
+                    }
+                    catch (err) {
+                        result1 = err;
+                    }
+
+                    expect(result2).to.be.undefined();
+                    expect(result1).to.exist();
+                },
+                connectionContext,
+                channelContext,
+                channelManager);
+            });
         });
     });
 });

--- a/test/BunnyBus/publish.js
+++ b/test/BunnyBus/publish.js
@@ -67,7 +67,7 @@ describe('BunnyBus', () => {
                 await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null);
             });
 
-            it('should publish for route `a`  when miscellaneous amqplib options are included', async () => {
+            it('should publish for route `a` when miscellaneous amqplib options are included', async () => {
 
                 const amqpOptions = {
                     expiration: '1000',
@@ -75,7 +75,7 @@ describe('BunnyBus', () => {
                     CC: 'a',
                     priority: 1,
                     persistent: false,
-                    deliveryMode: false,
+                    deliveryMode: 1,
                     mandatory:false,
                     BCC: 'b',
                     contentType: 'text/plain',
@@ -88,63 +88,106 @@ describe('BunnyBus', () => {
                     appId: 'test_app'
                 };
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, amqpOptions);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, amqpOptions, null);
+            });
+
+            it('should publish for route `a` when header options are included', async () => {
+
+                const headerOptions = {
+                    namespace: 'foo.bar::hello.world',
+                    id: 'abc-1Z_32G',
+                    eventType: 'type-G',
+                    schemaVrsion: '1.3.4'
+                };
+
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null, headerOptions);
+            });
+
+            it('should publish for route `a` when miscellaneous amqplib option and header options are included', async () => {
+
+                const headerOptions = {
+                    namespace: 'foo.bar::hello.world',
+                    id: 'abc-1Z_32G',
+                    eventType: 'type-G',
+                    schemaVrsion: '1.3.4'
+                };
+
+                const amqpOptions = {
+                    expiration: '1000',
+                    userId: 'guest',
+                    CC: 'a',
+                    priority: 1,
+                    persistent: false,
+                    deliveryMode: 1,
+                    mandatory:false,
+                    BCC: 'b',
+                    contentType: 'text/plain',
+                    contentEncoding: 'text/plain',
+                    correlationId: 'some_id',
+                    replyTo: 'other_queue',
+                    messageId: 'message_id',
+                    timestamp: 1555099550198,
+                    type: 'some_type',
+                    appId: 'test_app'
+                };
+
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, amqpOptions, headerOptions);
             });
 
             it('should publish for route `a.b`', async () => {
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a.b', null, null, true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a.b', null, null, true, null, null);
             });
 
             it('should publish for route `b`', async () => {
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'b', null, null, true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'b', null, null, true, null, null);
             });
 
             it('should publish for route `b.b`', async () => {
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'b.b', null, null, true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'b.b', null, null, true, null, null);
             });
 
             it('should publish for route `z.a`', async () => {
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'z.a', null, null, true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'z.a', null, null, true, null, null);
             });
 
             it('should publish for route `z` but not route to queue', async () => {
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'z', null, null, false, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'z', null, null, false, null, null);
             });
 
             it('should proxy `source` when supplied', async () => {
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, 'someModule', true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, 'someModule', true, null, null);
             });
 
             it('should proxy `transactionId` when supplied', async () => {
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', 'someTransactionId', null, true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', 'someTransactionId', null, true, null, null);
             });
 
             it('should publish for route `a` when route key is provided in the message', async () => {
 
                 const messageWithRoute = Object.assign({}, message, { event : 'a' });
 
-                await Assertions.assertPublish(instance, channelContext, messageWithRoute, baseQueueName, null, null, null, true, null);
+                await Assertions.assertPublish(instance, channelContext, messageWithRoute, baseQueueName, null, null, null, true, null, null);
             });
 
             it('should not error when connection does not pre-exist', async () => {
 
                 await connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null, null);
             });
 
             it('should not error when channel does not pre-exist', async () => {
 
                 await channelManager.close(BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName));
 
-                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null);
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null, null);
             });
         });
     });

--- a/test/BunnyBus/publish.js
+++ b/test/BunnyBus/publish.js
@@ -18,7 +18,6 @@ describe('BunnyBus', () => {
     before(() => {
 
         instance = new BunnyBus();
-        instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
         connectionManager = instance.connections;
         channelManager = instance.channels;
     });
@@ -34,9 +33,8 @@ describe('BunnyBus', () => {
 
             beforeEach(async () => {
 
+                instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
                 channelContext = await instance._autoBuildChannelContext(baseChannelName);
-
-
                 await channelContext.channel.assertQueue(baseQueueName);
             });
 
@@ -63,6 +61,13 @@ describe('BunnyBus', () => {
             });
 
             it('should publish for route `a`', async () => {
+
+                await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null);
+            });
+
+            it('should publish for route `a` when disableExchangeCreate === true', async () => {
+
+                instance.config = { disableExchangeCreate: true };
 
                 await Assertions.assertPublish(instance, channelContext, message, baseQueueName, 'a', null, null, true, null);
             });

--- a/test/assertions/assertPublish.js
+++ b/test/assertions/assertPublish.js
@@ -10,7 +10,7 @@ const assertPublish = async (instance, channelContext, message, queueName, route
         routeKey,
         transactionId,
         source,
-        header: headerOptions
+        headers: headerOptions
     };
 
     if (typeof miscOptions === 'object' && miscOptions !== null){

--- a/test/assertions/assertPublish.js
+++ b/test/assertions/assertPublish.js
@@ -4,12 +4,13 @@ const Code = require('@hapi/code');
 
 const expect = Code.expect;
 
-const assertPublish = async (instance, channelContext, message, queueName, routeKey, transactionId, source, shouldRoute, miscOptions) => {
+const assertPublish = async (instance, channelContext, message, queueName, routeKey, transactionId, source, shouldRoute, miscOptions, headerOptions) => {
 
     const options = {
         routeKey,
         transactionId,
-        source
+        source,
+        header: headerOptions
     };
 
     if (typeof miscOptions === 'object' && miscOptions !== null){
@@ -47,6 +48,24 @@ const assertPublish = async (instance, channelContext, message, queueName, route
 
         if (transactionId) {
             expect(payload.properties.headers.transactionId).to.be.equal(transactionId);
+        }
+
+        if (miscOptions) {
+            const copyMiscOptions = Object.assign({}, miscOptions);
+            delete copyMiscOptions.CC;
+            delete copyMiscOptions.BCC;
+            delete copyMiscOptions.persistent;
+            delete copyMiscOptions.mandatory;
+
+            expect(payload.properties).to.include(copyMiscOptions);
+
+            if (miscOptions.CC) {
+                expect(payload.properties.headers.CC).to.include(miscOptions.CC);
+            }
+        }
+
+        if (headerOptions) {
+            expect(payload.properties.headers).to.include(headerOptions);
         }
 
         channelContext.channel.ack(payload);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The changes here allow for header value forwarding with the `publish(...)` interface and allows for optionality to disable creation of queue and exchange. 
 
* `publish(...)` now accepts an `options.headers` value that will be overlayed into the `header` hash map that is sent.
* `config.disableQueueCreate` is introduced which disables queue creation connection wide.
* `config.disableExchangeCreate` is introduced which disables exchange creation connection wide.
* enhanced `assertPublisher(...)` test suite to better cross check miscellaneous options passed in.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changes needed to support notification integration for geo fences.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.