### PR TITLE
New resubscribe interface

### DIFF
--- a/API.md
+++ b/API.md
@@ -38,15 +38,17 @@
       - [handlers](#handlers)
       - [`key`](#key)
       - [`handler`](#handler)
-    - [`async unsubscribe(queue)`](#async-unsubscribequeue)
+    - [`async resubscribe(queue)`](#async-resubscribequeue)
       - [parameter(s)](#parameters-9)
+    - [`async unsubscribe(queue)`](#async-unsubscribequeue)
+      - [parameter(s)](#parameters-10)
     - [`await send(message, queue, [options])`](#await-sendmessage-queue-options)
       - [note(s)](#notes)
-      - [parameter(s)](#parameters-10)
-    - [`async get(queue, [options])`](#async-getqueue-options)
       - [parameter(s)](#parameters-11)
-    - [`async getAll(queue, handler, [options])`](#async-getallqueue-handler-options)
+    - [`async get(queue, [options])`](#async-getqueue-options)
       - [parameter(s)](#parameters-12)
+    - [`async getAll(queue, handler, [options])`](#async-getallqueue-handler-options)
+      - [parameter(s)](#parameters-13)
   - [Internal-use Methods](#internal-use-methods)
     - [`async _autoBuildChannelContext(channelName, [queue = null])`](#async-_autobuildchannelcontextchannelname-queue--null)
       - [`parameter(s)`](#parameters)
@@ -137,20 +139,20 @@
 - [`ConnectionManager`](#connectionmanager)
   - [Methods](#methods-1)
     - [`async create(name, connectionOptions, [socketOptions])`](#async-createname-connectionoptions-socketoptions)
-      - [parameter(s)](#parameters-13)
-    - [`contains(name)`](#containsname)
       - [parameter(s)](#parameters-14)
-    - [`get(name)`](#getname)
+    - [`contains(name)`](#containsname)
       - [parameter(s)](#parameters-15)
+    - [`get(name)`](#getname)
+      - [parameter(s)](#parameters-16)
     - [`list()`](#list)
     - [`hasConnection(name)`](#hasconnectionname)
-      - [parameter(s)](#parameters-16)
-    - [`getConnection(name)`](#getconnectionname)
       - [parameter(s)](#parameters-17)
-    - [`async remove(name)`](#async-removename)
+    - [`getConnection(name)`](#getconnectionname)
       - [parameter(s)](#parameters-18)
-    - [`async close(name)`](#async-closename)
+    - [`async remove(name)`](#async-removename)
       - [parameter(s)](#parameters-19)
+    - [`async close(name)`](#async-closename)
+      - [parameter(s)](#parameters-20)
   - [Events](#events-2)
     - [`ConnectionManager.CONNECTION_REMOVED`](#connectionmanagerconnection_removed-1)
       - [key value](#key-value-5)
@@ -181,20 +183,20 @@
 - [`ChannelManager`](#channelmanager)
   - [Methods](#methods-2)
     - [`async create(name, [queue = null], connectionContext, channelOptions)`](#async-createname-queue--null-connectioncontext-channeloptions)
-      - [parameter(s)](#parameters-20)
-    - [`contains(name)`](#containsname-1)
       - [parameter(s)](#parameters-21)
-    - [`get(name)`](#getname-1)
+    - [`contains(name)`](#containsname-1)
       - [parameter(s)](#parameters-22)
+    - [`get(name)`](#getname-1)
+      - [parameter(s)](#parameters-23)
     - [`list()`](#list-1)
     - [`hasChannel(name)`](#haschannelname)
-      - [parameter(s)](#parameters-23)
-    - [`getChannel(name)`](#getchannelname)
       - [parameter(s)](#parameters-24)
-    - [`async remove(name)`](#async-removename-1)
+    - [`getChannel(name)`](#getchannelname)
       - [parameter(s)](#parameters-25)
-    - [`async close(name)`](#async-closename-1)
+    - [`async remove(name)`](#async-removename-1)
       - [parameter(s)](#parameters-26)
+    - [`async close(name)`](#async-closename-1)
+      - [parameter(s)](#parameters-27)
   - [Events](#events-4)
     - [`ChannelManager.CHANNEL_REMOVED`](#channelmanagerchannel_removed-1)
       - [key value](#key-value-11)
@@ -573,6 +575,21 @@ const handlers = {
 }
 
 await bunnyBus.subscribe('queue', handlers);
+```
+
+#### `async resubscribe(queue)`
+
+Resubscribes non-active handlers to a queue.  This should be used with [`unsubscribe()`](#async-unsubscribequeue).
+
+##### parameter(s)
+
+  - `queue` - the name of the queue. *[string]* **Required**
+
+```javascript
+const BunnyBus = require('bunnybus');
+const bunnyBus = new BunnyBus();
+
+await bunnyBus.resubscribe('queue1');
 ```
 
 #### `async unsubscribe(queue)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -599,6 +599,14 @@ class BunnyBus extends EventEmitter{
         }
     }
 
+    async resubscribe(queue) {
+
+        if (this.subscriptions.contains(queue, false) && !this.subscriptions.contains(queue, true) && !this.subscriptions.isBlocked(queue)) {
+            const { handlers, options } = this.subscriptions.get(queue);
+            await this.subscribe(queue, handlers, options);
+        }
+    }
+
     //options to store calling module, queue name
     async _ack(payload, channelName, options) {
 

--- a/lib/states/subscriptionManager.js
+++ b/lib/states/subscriptionManager.js
@@ -44,11 +44,9 @@ class SubscriptionManager extends EventEmitter {
 
     contains(queue, withConsumerTag = true) {
 
-        if (withConsumerTag) {
-            return this._subscriptions.has(queue) && this._subscriptions.get(queue).hasOwnProperty('consumerTag');
-        }
-
-        return this._subscriptions.has(queue);
+        return withConsumerTag
+            ? this._subscriptions.has(queue) && this._subscriptions.get(queue).hasOwnProperty('consumerTag')
+            : this._subscriptions.has(queue);
     }
 
     create(queue, handlers, options) {

--- a/test/BunnyBus/resubscribe-unsubscribe/single-queue.js
+++ b/test/BunnyBus/resubscribe-unsubscribe/single-queue.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const BunnyBus = require('../../../lib');
+
+const { describe, before, beforeEach, after, afterEach, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+let instance = undefined;
+let channelContext = undefined;
+
+describe('BunnyBus', () => {
+
+    before(() => {
+
+        instance = new BunnyBus();
+        instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+    });
+
+    describe('public methods', () => {
+
+        describe('resubscribe / unsubscribe (single queue)', () => {
+
+            const baseChannelName = 'bunnybus-resubscribe';
+            const baseQueueName = 'test-resubscribe-queue';
+            const baseErrorQueueName = `${baseQueueName}_error`;
+            const publishOptions = { routeKey : 'a.b' };
+            const subscribeOptionsWithMeta = { meta : true };
+            const messageObject = { event : 'a.b', name : 'bunnybus' };
+            const messageString = 'bunnybus';
+            const messageBuffer = Buffer.from(messageString);
+
+            before(async () => {
+
+                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+
+                await Promise.all([
+                    channelContext.channel.deleteExchange(instance.config.globalExchange),
+                    channelContext.channel.deleteQueue(baseQueueName),
+                    channelContext.channel.deleteQueue(baseErrorQueueName)
+                ]);
+            });
+
+            afterEach(async () => {
+
+                await instance.unsubscribe(baseQueueName);
+            });
+
+            after(async () => {
+
+                await Promise.all([
+                    channelContext.channel.deleteExchange(instance.config.globalExchange),
+                    channelContext.channel.deleteQueue(baseQueueName),
+                    channelContext.channel.deleteQueue(baseErrorQueueName)
+                ]);
+            });
+
+            it('should consume message (Object) from queue and acknowledge off', async () => {
+
+                return new Promise(async (resolve) => {
+
+                    await instance.subscribe(baseQueueName, {
+                        [messageObject.event]: async (consumedMessage, ack) => {
+
+                            expect(consumedMessage).to.be.equal(messageObject);
+
+                            await ack();
+                            resolve();
+                        }
+                    }),
+
+                    await instance.unsubscribe(baseQueueName);
+                    await instance.resubscribe(baseQueueName);
+                    await instance.publish(messageObject);
+                });
+            });
+
+            it('should not reject when handler subscription exist', async () => {
+
+                return new Promise(async (resolve) => {
+
+                    await instance.subscribe(baseQueueName, {
+                        [messageObject.event]: async (consumedMessage, ack) => {
+
+                            expect(consumedMessage).to.be.equal(messageObject);
+
+                            await ack();
+                            resolve();
+                        }
+                    }),
+
+                    await expect(instance.resubscribe(baseQueueName)).to.not.reject();
+                    await instance.publish(messageObject);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding a new `resubscribe(queueName)` method to BunnyBus to enable reassignment of handlers and their declared optionality when `unsubscribe(...)` is called prior.  

## Motivation and Context
Work needed for circuit breaker.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.