### PR TITLE
Timeout problem with ManagmentClient Initialization.

### DIFF
--- a/lib/clients/managementClient.js
+++ b/lib/clients/managementClient.js
@@ -35,12 +35,15 @@ class ManagementClient {
         (
             await Promise.allSettled([
                 Request.get(`http://${hostname}:15672/api/overview`)
+                    .timeout(1000)
                     .auth(username, password)
                     .then(() => `http://${hostname}:15672`),
                 Request.get(`http://${hostname}/api/overview`)
+                    .timeout(1000)
                     .auth(username, password)
                     .then(() => `http://${hostname}`),
                 Request.get(`https://${hostname}/api/overview`)
+                    .timeout(1000)
                     .auth(username, password)
                     .then(() => `https://${hostname}`)
             ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using the new ManagementClient in a real environment, the CloudAMQP response stack holds the socket open when the response should not be valid.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.