### PR TITLE
Poison Message Handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -292,6 +292,7 @@ Setter and Getter for configuration. Accepts the following optional properties:
 * `disableExchangeCreate` - flag to dictate if automatic exchange creation should be turned on/off.  Defaults to `false`.  *[boolean]* **Optional**
  * `dispatchType` - enumerated value to select dispatch mechanism used.  `serial` will flow messages to your message handler(s) in single file.  `concurrent` will flow messages simultaneously to your message handler(s).  Defaults to `serial`.  *[string]* **Optional**
  * `rejectUnroutedMessages` - flag to direct messages that were unroutable to provided handlers to either be automatically rejected or acknowledged off the queue.  The default is silent acknowledgements.  Defaults to `false`.  *[boolean]* **Optional**
+ * `rejectPoisonMessages` - flag to direct poison messages to be automatically rejected to a poison queue or acknowledged off the queue.  The default is to forward the message to a poison queue.  Defaults to `true`.  *[boolean]*
 
 Note that updates in the options directed at changing connection string will not take affect immediately.  [`ConnectionManager.close()`](#async-closename) needs to be called manually to invoke a new connection with new settings.
 
@@ -574,6 +575,7 @@ Subscribe to messages from a given queue.
     - `validateVersion` - flag for validating messages generated from the same major version.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
     - `disableQueueBind` - flag for disabling automatic queue binding.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* **Optional**
     - `rejectUnroutedMessages` - flag for enabling rejection for unroutable messages.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
+    - `rejectPoisonMessages` - flag for enabling rejection for poison messages.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
     - `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
 
 ##### handlers

--- a/API.md
+++ b/API.md
@@ -575,7 +575,7 @@ Subscribe to messages from a given queue.
     - `validateVersion` - flag for validating messages generated from the same major version.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
     - `disableQueueBind` - flag for disabling automatic queue binding.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* **Optional**
     - `rejectUnroutedMessages` - flag for enabling rejection for unroutable messages.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
-    - `rejectPoisonMessages` - flag for enabling rejection for poison messages.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
+    - `rejectPoisonMessages` - flag for enabling rejection for poison messages.  A poison queue is named by default to `<your queue name>_poison`.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
     - `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
 
 ##### handlers
@@ -591,7 +591,7 @@ A `handler` is an asynchronous function which contains the following arity.  Ord
   - `meta` is only available when `options.meta` is set to `true`.  This object will contain all payload related meta information like `payload.properties.headers`. Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.
   - `async ack([option)` is an async function for acknowledging the message off the bus.
     - `option` - a placeholder for future optional parameters for `ack`.  High chance of deprecation.
-  - `async reject([option)` is an async function for rejecting the message off the bus to a predefined error queue.  The error queue is named by default `<your queue name>_error`.  It will also short circuit to `error_bus` when defaults can't be found.
+  - `async reject([option)` is an async function for rejecting the message off the bus to a predefined error queue.  The error queue is named by default to `<your queue name>_error`.  It will also short circuit to `error_bus` when defaults can't be found.
     - `option` - An object with a property of `reason` to be supplied. *[Object]* **Optional**
   - `async requeue()` is an async function for requeuing the message back to the back of the queue.  This is feature circumvents Rabbit's `nack` RPC.  `nack` natively requeues but pushes the message to the front of the queue.
 

--- a/lib/helpers/defaultConfiguration.js
+++ b/lib/helpers/defaultConfiguration.js
@@ -21,6 +21,7 @@ module.exports = {
         validateVersion: false,
         dispatchType: 'serial',
         rejectUnroutedMessages: false,
+        rejectPoisonMessages: true,
         disableQueueBind: false,
         disableQueueCreate: false,
         disableExchangeCreate: false

--- a/lib/helpers/parsePayload.js
+++ b/lib/helpers/parsePayload.js
@@ -1,12 +1,18 @@
 'use strict';
 
-const parsePayload = (payload) => {
-    return {
-        message: payload.properties.headers.isBuffer ? payload.content : JSON.parse(payload.content.toString()),
-        metaData: {
-            headers: Object.assign({}, payload.properties.headers)
-        }
-    };
+const parsePayload = ({ content = null, properties: { headers = {} } = {} }) => {
+    let result = null;
+
+    try {
+        result = {
+            message: headers.isBuffer ? content : JSON.parse(content.toString()),
+            metaData: {
+                headers: Object.assign({}, headers)
+            }
+        };
+    } catch (err) {}
+
+    return result;
 };
 
 module.exports = parsePayload;

--- a/lib/helpers/timeoutAsync.js
+++ b/lib/helpers/timeoutAsync.js
@@ -2,21 +2,16 @@
 
 const timeoutAsync = (asyncFunc, timeout = 100) => {
     return async (...args) => {
-        let handled = false;
-
         return new Promise(async (resolve, reject) => {
             const timeoutRef = setTimeout(() => {
-                handled = true;
                 reject(new Error('Timeout occurred'));
             }, timeout);
 
             try {
                 const result = await asyncFunc(...args);
 
-                if (!handled) {
-                    clearTimeout(timeoutRef);
-                    resolve(result);
-                }
+                clearTimeout(timeoutRef);
+                resolve(result);
             } catch (err) {
                 clearTimeout(timeoutRef);
                 reject(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -394,6 +394,7 @@ class BunnyBus extends EventEmitter {
             if (payload) {
                 const parsedPayload = Helpers.parsePayload(payload);
 
+                // Not currently handling poison message unlike subscribe
                 if (meta) {
                     await handler(
                         parsedPayload.message,
@@ -474,6 +475,10 @@ class BunnyBus extends EventEmitter {
             options && options.hasOwnProperty('rejectUnroutedMessages')
                 ? options.rejectUnroutedMessages
                 : this.config.rejectUnroutedMessages;
+        const rejectPoisonMessages =
+            options && options.hasOwnProperty('rejectPoisonMessages')
+                ? options.rejectPoisonMessages
+                : this.config.rejectPoisonMessages;
         const meta = options && options.meta;
         const channelName = BunnyBus.QUEUE_CHANNEL_NAME(queue);
 
@@ -490,68 +495,81 @@ class BunnyBus extends EventEmitter {
         const result = await channelContext.channel.consume(queue, async (payload) => {
             if (payload) {
                 const parsedPayload = Helpers.parsePayload(payload);
-                const routeKey = Helpers.reduceRouteKey(payload, null, parsedPayload.message);
-                const currentRetryCount = payload.properties.headers.retryCount || -1;
                 const errorQueue = `${queue}_error`;
-                const matchedHandlers = Helpers.handlerMatcher(handlers, routeKey);
+                const poisonQueue = `${queue}_poison`;
 
-                if (matchedHandlers.length > 0) {
-                    // check for `bunnyBus` header first
-                    if (
-                        validatePublisher &&
-                        !(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)
-                    ) {
-                        const reason = 'message not of BunnyBus origin';
-                        this.logger.warn(reason);
-                        await this._reject(payload, channelName, errorQueue, { reason });
-                    }
-                    // check for `bunnyBus`:<version> semver
-                    else if (
-                        validatePublisher &&
-                        validateVersion &&
-                        !Helpers.isMajorCompatible(payload.properties.headers.bunnyBus)
-                    ) {
-                        const reason = `message came from older bunnyBus version (${payload.properties.headers.bunnyBus})`;
-                        this.logger.warn(reason);
-                        await this._reject(payload, channelName, errorQueue, { reason });
-                    } else if (currentRetryCount < maxRetryCount) {
-                        matchedHandlers.forEach(async (matchedHandler) => {
-                            this._dispatchers[this.config.dispatchType].push(queue, async () => {
-                                this.emit(
-                                    BunnyBus.MESSAGE_DISPATCHED_EVENT,
-                                    parsedPayload.metaData,
-                                    parsedPayload.message
-                                );
-                                if (meta) {
-                                    await matchedHandler(
-                                        parsedPayload.message,
+                if (parsedPayload) {
+                    const routeKey = Helpers.reduceRouteKey(payload, null, parsedPayload.message);
+                    const currentRetryCount = payload.properties.headers.retryCount || -1;
+
+                    const matchedHandlers = Helpers.handlerMatcher(handlers, routeKey);
+                    if (parsedPayload && matchedHandlers.length > 0) {
+                        // check for `bunnyBus` header first
+                        if (
+                            validatePublisher &&
+                            !(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)
+                        ) {
+                            const reason = 'message not of BunnyBus origin';
+                            this.logger.warn(reason);
+                            await this._reject(payload, channelName, errorQueue, { reason });
+                        }
+                        // check for `bunnyBus`:<version> semver
+                        else if (
+                            validatePublisher &&
+                            validateVersion &&
+                            !Helpers.isMajorCompatible(payload.properties.headers.bunnyBus)
+                        ) {
+                            const reason = `message came from older bunnyBus version (${payload.properties.headers.bunnyBus})`;
+                            this.logger.warn(reason);
+                            await this._reject(payload, channelName, errorQueue, { reason });
+                        } else if (currentRetryCount < maxRetryCount) {
+                            matchedHandlers.forEach(async (matchedHandler) => {
+                                this._dispatchers[this.config.dispatchType].push(queue, async () => {
+                                    this.emit(
+                                        BunnyBus.MESSAGE_DISPATCHED_EVENT,
                                         parsedPayload.metaData,
-                                        this._ack.bind(this, payload, channelName),
-                                        this._reject.bind(this, payload, channelName, errorQueue),
-                                        this._requeue.bind(this, payload, channelName, queue, {
-                                            routeKey
-                                        })
+                                        parsedPayload.message
                                     );
-                                } else {
-                                    await matchedHandler(
-                                        parsedPayload.message,
-                                        this._ack.bind(this, payload, channelName),
-                                        this._reject.bind(this, payload, channelName, errorQueue),
-                                        this._requeue.bind(this, payload, channelName, queue)
-                                    );
-                                }
+                                    if (meta) {
+                                        await matchedHandler(
+                                            parsedPayload.message,
+                                            parsedPayload.metaData,
+                                            this._ack.bind(this, payload, channelName),
+                                            this._reject.bind(this, payload, channelName, errorQueue),
+                                            this._requeue.bind(this, payload, channelName, queue, {
+                                                routeKey
+                                            })
+                                        );
+                                    } else {
+                                        await matchedHandler(
+                                            parsedPayload.message,
+                                            this._ack.bind(this, payload, channelName),
+                                            this._reject.bind(this, payload, channelName, errorQueue),
+                                            this._requeue.bind(this, payload, channelName, queue)
+                                        );
+                                    }
+                                });
                             });
-                        });
+                        } else {
+                            const reason = `message passed retry limit of ${maxRetryCount} for routeKey (${routeKey})`;
+                            this.logger.warn(reason);
+                            await this._reject(payload, channelName, errorQueue, { reason });
+                        }
                     } else {
-                        const reason = `message passed retry limit of ${maxRetryCount} for routeKey (${routeKey})`;
+                        const reason = `message consumed with no matching routeKey (${routeKey}) handler`;
                         this.logger.warn(reason);
-                        await this._reject(payload, channelName, errorQueue, { reason });
+                        if (rejectUnroutedMessages) {
+                            await this._reject(payload, channelName, errorQueue, { reason });
+                        } else {
+                            // acking this directly to channel so events don't fire
+                            await channelContext.channel.ack(payload);
+                        }
                     }
                 } else {
-                    const reason = `message consumed with no matching routeKey (${routeKey}) handler`;
+                    const reason = `corrupted payload content intercepted`;
                     this.logger.warn(reason);
-                    if (rejectUnroutedMessages) {
-                        await this._reject(payload, channelName, errorQueue, { reason });
+                    if (rejectPoisonMessages) {
+                        await this._reject(payload, channelName, poisonQueue, { reason });
                     } else {
                         // acking this directly to channel so events don't fire
                         await channelContext.channel.ack(payload);
@@ -652,8 +670,13 @@ class BunnyBus extends EventEmitter {
         await channelContext.channel.waitForConfirms();
         await channelContext.channel.ack(payload);
 
-        const parsedPayload = Helpers.parsePayload(payload);
-        parsedPayload.metaData.headers = Object.assign(parsedPayload.metaData.headers, headers);
+        let parsedPayload = Helpers.parsePayload(payload);
+
+        if (parsedPayload) {
+            parsedPayload.metaData.headers = Object.assign(parsedPayload.metaData.headers, headers);
+        } else {
+            parsedPayload = {};
+        }
 
         this.emit(BunnyBus.MESSAGE_REJECTED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -241,9 +241,9 @@ class BunnyBus extends EventEmitter {
         // may get caught with a corrupted channel context where the channel is inoperable,
         // but still set to the context
         try {
-            await Helpers.timeoutAsync(async () => await promise, 500);
+            await Helpers.timeoutAsync(async () => await promise, 500)();
         } catch (err) {
-            if (err.Message !== 'Timeout occurred') {
+            if (err.message !== 'Timeout occurred') {
                 throw err;
             }
         } finally {
@@ -286,9 +286,9 @@ class BunnyBus extends EventEmitter {
         // may get caught with a corrupted channel context where the channel is inoperable,
         // but still set to the context
         try {
-            await Helpers.timeoutAsync(async () => await promise, 500);
+            await Helpers.timeoutAsync(async () => await promise, 500)();
         } catch (err) {
-            if (err.Message !== 'Timeout occurred') {
+            if (err.message !== 'Timeout occurred') {
                 throw err;
             }
         } finally {

--- a/test/BunnyBus/end-to-end/poison-messages.js
+++ b/test/BunnyBus/end-to-end/poison-messages.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const BunnyBus = require('../../../lib');
+const { ChannelManager } = require('../../../lib/states');
+
+const { describe, before, beforeEach, after, afterEach, it } = (exports.lab = Lab.script());
+const expect = Code.expect;
+
+let instance = undefined;
+let connectionManager = undefined;
+const connectionContext = undefined;
+let channelManager = undefined;
+let channelContext = undefined;
+
+describe('BunnyBus', () => {
+    describe('end to end behaviors', () => {
+        describe('edge cases', () => {
+            const baseChannelName = 'bunnybus-e2e-poison-messages';
+            const baseQueueName = 'test-e2e-poison-messages-queue';
+            const basePoisonQueueName = `${baseQueueName}_poison`;
+
+            beforeEach(async () => {
+                instance = new BunnyBus();
+                instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+                connectionManager = instance.connections;
+                channelManager = instance.channels;
+
+                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+            });
+
+            after(async () => {
+                await channelContext.channel.deleteQueue(baseQueueName);
+                await channelContext.channel.deleteQueue(basePoisonQueueName);
+            });
+
+            it('should error when message caught by subscribe is not a deserializable JSON buffer', async () => {
+                const badJSONBuffer = Buffer.from('{ "hello": "world ', 'utf-8');
+
+                // This will never be called
+                await instance.subscribe(baseQueueName, {
+                    ec: async (consumedMessage, ack) => {
+                        await ack();
+                    }
+                });
+
+                // send the poison message
+                channelContext.channel.sendToQueue(baseQueueName, badJSONBuffer, { headers: { routeKey: 'ec' } });
+
+                await new Promise((resolve) => {
+                    instance.once(BunnyBus.MESSAGE_REJECTED_EVENT, async () => {
+                        expect(await instance.get(basePoisonQueueName)).to.exist();
+                        resolve();
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/BunnyBus/end-to-end/poison-messages.js
+++ b/test/BunnyBus/end-to-end/poison-messages.js
@@ -4,7 +4,7 @@ const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const BunnyBus = require('../../../lib');
 const { ChannelManager } = require('../../../lib/states');
-const helpers = require('../../../lib/helpers');
+const Helpers = require('../../../lib/helpers');
 
 const { describe, before, beforeEach, after, afterEach, it } = (exports.lab = Lab.script());
 const expect = Code.expect;
@@ -79,7 +79,7 @@ describe('BunnyBus', () => {
                 channelContext.channel.sendToQueue(baseQueueName, badJSONBuffer, { headers: { routeKey: 'ec' } });
 
                 await expect(
-                    helpers.timeoutAsync(
+                    Helpers.timeoutAsync(
                         async () =>
                             await new Promise((resolve) => {
                                 instance.once(BunnyBus.MESSAGE_REJECTED_EVENT, async () => {

--- a/test/BunnyBus/purgeQueue.js
+++ b/test/BunnyBus/purgeQueue.js
@@ -43,18 +43,8 @@ describe('BunnyBus', () => {
             it(`should purge a queue with name ${baseQueueName}`, async () => {
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        let result1 = null;
-
-                        const result2 = await instance.purgeQueue(baseQueueName);
-
-                        try {
-                            await channelContext.channel.checkQueue(baseQueueName);
-                        } catch (err) {
-                            result1 = err;
-                        }
-
-                        expect(result1).to.not.exist();
-                        expect(result2).to.be.true();
+                        expect(await instance.purgeQueue(baseQueueName)).to.be.true();
+                        await expect(channelContext.channel.checkQueue(baseQueueName)).to.not.reject();
                     },
                     connectionContext,
                     channelContext,
@@ -67,18 +57,7 @@ describe('BunnyBus', () => {
 
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        let result1 = null;
-                        let result2 = null;
-
-                        try {
-                            result2 = await instance.purgeQueue(baseQueueName);
-                        } catch (err) {
-                            result1 = err;
-                        }
-
-                        expect(result1).to.not.exist();
-                        expect(result2).to.be.false();
-                        // expect(result2.messageCount).to.equal(1);
+                        expect(await instance.purgeQueue(baseQueueName)).to.be.false();
                     },
                     connectionContext,
                     channelContext,

--- a/test/BunnyBus/subscribe-unsubscribe/single-queue.js
+++ b/test/BunnyBus/subscribe-unsubscribe/single-queue.js
@@ -90,8 +90,8 @@ describe('BunnyBus', () => {
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers),
-                        await instance.publish(messageString, publishOptions);
+                    await instance.subscribe(baseQueueName, handlers);
+                    await instance.publish(messageString, publishOptions);
                 });
             });
 

--- a/test/helpers/parsePayload.js
+++ b/test/helpers/parsePayload.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const Helpers = require('../../lib/helpers');
+
+const { describe, before, beforeEach, after, it } = (exports.lab = Lab.script());
+const expect = Code.expect;
+
+describe('Helpers', () => {
+    describe('parsePayload', () => {
+        it('should parse JSON payload', () => {
+            const payload = {
+                content: Buffer.from('{"hello":"world"}', 'utf-8')
+            };
+
+            expect(Helpers.parsePayload(payload)).to.contain({
+                message: { hello: 'world' }
+            });
+        });
+
+        it('should proxy buffer payload', () => {
+            const buffer = Buffer.from('abcdefghijklmnopqrstuvwxyz', 'utf-8');
+
+            const payload = {
+                properties: {
+                    headers: {
+                        isBuffer: true
+                    }
+                },
+                content: buffer
+            };
+
+            expect(Helpers.parsePayload(payload)).to.contain({
+                message: buffer
+            });
+        });
+
+        it('should return empty headers when payload header is missing', () => {
+            const payload = {
+                properties: {},
+                content: Buffer.from('{"hello":"world"}', 'utf-8')
+            };
+
+            expect(Helpers.parsePayload(payload)).to.contain({
+                metaData: {
+                    headers: {}
+                }
+            });
+        });
+
+        it('should return empty headers when payload properties is missing', () => {
+            const payload = {
+                content: Buffer.from('{"hello":"world"}', 'utf-8')
+            };
+
+            expect(Helpers.parsePayload(payload)).to.contain({
+                metaData: {
+                    headers: {}
+                }
+            });
+        });
+
+        it('should return null when payload content is missing', () => {
+            const payload = {};
+
+            expect(Helpers.parsePayload(payload)).to.be.null();
+        });
+
+        it('should return null when payload content is empty string', () => {
+            const payload = { content: '' };
+
+            expect(Helpers.parsePayload(payload)).to.be.null();
+        });
+
+        it('shold return null when payload content is non deserializable corrupted JSON buffer', () => {
+            const buffer = Buffer.from('{"hello":"world"', 'utf-8');
+
+            const payload = { content: buffer };
+
+            expect(Helpers.parsePayload(payload)).to.be.null();
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This resolves unhandled errors when a message contains a buffer that is `isBuffer = false` and the content is not JSON deserializable.  Currently, the `subscribe(...)` block does a hard crash and exits the process, but leaves the message in the queue.  Successive restarts of the process loops back into the same error mode.  This fix address this by catching this error, and forwarding the message to a new `<queue-name>_poison` queue.  The forwarding mechanism is on by default and is controlled by the `rejectPoisonMessages` flag.  When the flag is turned off, silent acknowledgement is used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixing crashing loops.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.