### PR TITLE
Multiple Handler Matched For Single Queue Dispatch Bug

### DIFF
--- a/lib/helpers/handlerMatcher.js
+++ b/lib/helpers/handlerMatcher.js
@@ -8,6 +8,7 @@ const handlerMatcher = (handlers, match) => {
     for (const key in handlers) {
         if (RouteMatcher(key, match)) {
             result.push(handlers[key]);
+            break;
         }
     }
 

--- a/test/helpers/handleMatcher.js
+++ b/test/helpers/handleMatcher.js
@@ -44,7 +44,7 @@ describe('Helpers', () => {
             const result = Helpers.handlerMatcher(handlers, 'abc.hello.xyz');
 
             expect(result).to.be.an.array();
-            expect(result).to.have.length(2);
+            expect(result).to.have.length(1);
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When multiple handlers are subscribed against a queue, it was possible for these handlers to all have distinct route keys that match against the same topic.  This violates the condition that a message should only be delivered once and acknowledged once.  When this handler setup condition happens, delivery will target the first handler that meets the match condition.

https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.ack.delivery-tag

> A message MUST not be acknowledged more than once

## Related Issue
I found this to be an issue as @ten-any and I were talking about testing scenarios with `bunnybus`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.