### PR TITLE
New optional error queue configuration for the reject interface

### DIFF
--- a/API.md
+++ b/API.md
@@ -428,9 +428,9 @@ Creates an exchange.
 
 ##### parameter(s)
 
-  - `name` - name of the exchange to be created. *[string]* **Required**
-  - `type` - type of exchange to create. Possible values are (`direct`, `fanout`, `header`, `topic`) *[string]* **Required**
-  - `options` - optional settings.  [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertExchange) are proxied through to amqplib `assertExchange`. *[Object]* **Optional**
+  * `name` - name of the exchange to be created. *[string]* **Required**
+  * `type` - type of exchange to create. Possible values are (`direct`, `fanout`, `header`, `topic`) *[string]* **Required**
+  * `options` - optional settings.  [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertExchange) are proxied through to amqplib `assertExchange`. *[Object]* **Optional**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -445,8 +445,8 @@ Delete an exchange.
 
 ##### parameter(s)
 
-  - `name` - name of the exchange to be deleted. *[string]* **Required**
-  - `options` - optional settings. [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_deleteExchange) are proxed through to amqplib `deleteExchange`. *[Object]* **Optional**
+  * `name` - name of the exchange to be deleted. *[string]* **Required**
+  * `options` - optional settings. [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_deleteExchange) are proxed through to amqplib `deleteExchange`. *[Object]* **Optional**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -461,7 +461,7 @@ Checks if an exchange exists.  The channel closes when the exchange does not exi
 
 ##### parameter(s)
 
-  - `name` - name of the exchange to be checked. *[string]* **Required**
+  * `name` - name of the exchange to be checked. *[string]* **Required**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -476,8 +476,8 @@ Creates a queue.
 
 ##### parameter(s)
 
-  - `name` - name of the queue to be created. *[string]* **Required**
-  - `options` - optional settings.  [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue) are proxied through to amqplib `assertQueue`. *[Object]* **Optional**
+  * `name` - name of the queue to be created. *[string]* **Required**
+  * `options` - optional settings.  [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue) are proxied through to amqplib `assertQueue`. *[Object]* **Optional**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -492,8 +492,8 @@ Delete a queue.
 
 ##### parameter(s)
 
-  - `name` - name of the queue to be created. *[string]* **Required**
-  - `options` - optional settings.  [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_deleteQueue) are proxied through to amqplib `deleteQueue`. *[Object]* **Optional**
+  * `name` - name of the queue to be created. *[string]* **Required**
+  * `options` - optional settings.  [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_deleteQueue) are proxied through to amqplib `deleteQueue`. *[Object]* **Optional**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -508,7 +508,7 @@ Checks if a queue exists.  Returns a queue info object `{ queue, messageCount, c
 
 ##### parameter(s)
 
-  - `name` - name of the queue to be checked. *[string]* **Required**
+  * `name` - name of the queue to be checked. *[string]* **Required**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -523,7 +523,7 @@ Purges a queue.  Will not throw error in cases where queue does not exist.
 
 ##### parameter(s)
 
-  - `name` - name of the queue to be purged. *[string]* **Required**
+  * `name` - name of the queue to be purged. *[string]* **Required**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -538,15 +538,15 @@ Publish a message onto the bus.
 
 ##### parameter(s)
 
-  - `message` - the content being sent to downstream subscribers. *[string|Object|Buffer]* **Required**
-   - `event` - override value for the route key. The value must be supplied here or in `options.routeKey`.  The value can be `.` separated for namespacing. *[string]* **Optional.**
-  - `options` - optional settings. *[Object]* **Optional**
-    - `routeKey` - value for the route key to route the message with.  The value must be supplied here or in `message.event`.  The value can be `.` separated for namespacing. *[string]* **Optional**
-    - `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]* **Optional**
-    - `source` - value attached to the header of the message to help with track the origin of messages in your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]* **Optional**
-    - `globalExchange` - value to override the exchange specified in [`config`](#config). *[string]* **Optional**
-    - `headers` - object used to overlay into the message request header (`payload.properties.headers`).  *[Object]* **Optional**
-    - In addition to the above options, all of `amqplib`'s [configuration options](http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish) (except for `headers` and `immediate`) from its `sendToQueue` and `publish` methods can also be passed as top-level properties in the `publish` options.
+  * `message` - the content being sent to downstream subscribers. *[string|Object|Buffer]* **Required**
+   * `event` - override value for the route key. The value must be supplied here or in `options.routeKey`.  The value can be `.` separated for namespacing. *[string]* **Optional.**
+  * `options` - optional settings. *[Object]* **Optional**
+    * `routeKey` - value for the route key to route the message with.  The value must be supplied here or in `message.event`.  The value can be `.` separated for namespacing. *[string]* **Optional**
+    * `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]* **Optional**
+    * `source` - value attached to the header of the message to help with track the origin of messages in your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]* **Optional**
+    * `globalExchange` - value to override the exchange specified in [`config`](#config). *[string]* **Optional**
+    * `headers` - object used to overlay into the message request header (`payload.properties.headers`).  *[Object]* **Optional**
+    * In addition to the above options, all of `amqplib`'s [configuration options](http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish) (except for `headers` and `immediate`) from its `sendToQueue` and `publish` methods can also be passed as top-level properties in the `publish` options.
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -566,18 +566,18 @@ Subscribe to messages from a given queue.
 
 ##### parameter(s)
 
-  - `queue` - the name of the queue to subscribe messages to. A queue with the provided name will be created if one does not exist. *[string]* **Required**
-  - `handlers` - a `key` / `handler` hash where the key reflects the name of the `message.event` or `routeKey`.  And the handler reflects a `AsyncFunction` as `async (message, [meta, [ack, [reject, [requeue]]]]) => {}`. *[Object]* **Required**
-  - `options` - optional settings. *[Object]* **Optional**
-    - `queue` - settings for the queue. [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue) are proxied through to amqplib `assertQueue`. *[Object]* **Optional**
-    - `globalExchange` - value of the exchange to transact through for message publishing.  Defaults to one provided in the [config](#config). *[string]* **Optional**
-    - `maxRetryCount` - maximum amount of attempts a message can be requeued.  Defaults to one provided in the [config](#config). *[number]* **Optional**
-    - `validatePublisher` - flag for validating messages having `bunnyBus` header.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
-    - `validateVersion` - flag for validating messages generated from the same major version.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
-    - `disableQueueBind` - flag for disabling automatic queue binding.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* **Optional**
-    - `rejectUnroutedMessages` - flag for enabling rejection for unroutable messages.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
-    - `rejectPoisonMessages` - flag for enabling rejection for poison messages.  A poison queue is named by default to `<your queue name>_poison`.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
-    - `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
+  * `queue` - the name of the queue to subscribe messages to. A queue with the provided name will be created if one does not exist. *[string]* **Required**
+  * `handlers` - a `key` / `handler` hash where the key reflects the name of the `message.event` or `routeKey`.  And the handler reflects a `AsyncFunction` as `async (message, [meta, [ack, [reject, [requeue]]]]) => {}`. *[Object]* **Required**
+  * `options` - optional settings. *[Object]* **Optional**
+    * `queue` - settings for the queue. [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue) are proxied through to amqplib `assertQueue`. *[Object]* **Optional**
+    * `globalExchange` - value of the exchange to transact through for message publishing.  Defaults to one provided in the [config](#config). *[string]* **Optional**
+    * `maxRetryCount` - maximum amount of attempts a message can be requeued.  Defaults to one provided in the [config](#config). *[number]* **Optional**
+    * `validatePublisher` - flag for validating messages having `bunnyBus` header.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
+    * `validateVersion` - flag for validating messages generated from the same major version.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
+    * `disableQueueBind` - flag for disabling automatic queue binding.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* **Optional**
+    * `rejectUnroutedMessages` - flag for enabling rejection for unroutable messages.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
+    * `rejectPoisonMessages` - flag for enabling rejection for poison messages.  A poison queue is named by default to `<your queue name>_poison`.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
+    * `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
 
 ##### handlers
 
@@ -588,13 +588,15 @@ A `key` is the routeKey in RabbitMQ terminology.  `BunnyBus` specifically levera
 ##### `handler`
 
 A `handler` is an asynchronous function which contains the following arity.  Order matters.
-  - `message` is what was received from the bus.  The message does represent the RabbitMQ `'payload.content` buffer.  The original source of this object is from `payload.content`.
-  - `meta` is only available when `options.meta` is set to `true`.  This object will contain all payload related meta information like `payload.properties.headers`. Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.
-  - `async ack([option)` is an async function for acknowledging the message off the bus.
-    - `option` - a placeholder for future optional parameters for `ack`.  High chance of deprecation.
-  - `async reject([option)` is an async function for rejecting the message off the bus to a predefined error queue.  The error queue is named by default to `<your queue name>_error`.  It will also short circuit to `error_bus` when defaults can't be found.
-    - `option` - An object with a property of `reason` to be supplied. *[Object]* **Optional**
-  - `async requeue()` is an async function for requeuing the message back to the back of the queue.  This is feature circumvents Rabbit's `nack` RPC.  `nack` natively requeues but pushes the message to the front of the queue.
+  * `message` is what was received from the bus.  The message does represent the RabbitMQ `'payload.content` buffer.  The original source of this object is from `payload.content`.
+  * `meta` is only available when `options.meta` is set to `true`.  This object will contain all payload related meta information like `payload.properties.headers`. Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.
+  * `async ack([option])` is an async function for acknowledging the message off the bus.
+    * `option` - a placeholder for future optional parameters for `ack`.  High chance of deprecation.
+  * `async reject([option])` is an async function for rejecting the message off the bus to a predefined error queue.  The error queue is named by default to `<your queue name>_error`.  It will also short circuit to `error_bus` when defaults can't be found.
+    * `option` *[Object]* **Optional**
+      * `reason` - A string that should describe the reason the message is being rejcted *[String]* **Optional**
+      * `errorQueue` - A string for a specific error queue that the message should be routed to. *[String]* **Optional**
+  * `async requeue()` is an async function for requeuing the message back to the back of the queue.  This is feature circumvents Rabbit's `nack` RPC.  `nack` natively requeues but pushes the message to the front of the queue.
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -622,7 +624,7 @@ Resubscribes non-active handlers to a queue.  This should be used with [`unsubsc
 
 ##### parameter(s)
 
-  - `queue` - the name of the queue. *[string]* **Required**
+  -*`queue` - the name of the queue. *[string]* **Required**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -637,7 +639,7 @@ Unsubscribe active handlers that are listening to a queue.
 
 ##### parameter(s)
 
-  - `queue` - the name of the queue. *[string]* **Required**
+  * `queue` - the name of the queue. *[string]* **Required**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -656,14 +658,14 @@ When `message.event` or `options.routeKey` values are not provided for `routeKey
 
 ##### parameter(s)
 
-  - `message` - the content being sent directly to specfied queue. *[string|Object|Buffer]* **Required**
-   - `event` - override value for the route key. The value must be supplied here or in `options.routeKey`.  The value can be `.` separated for namespacing. *[string]* **Optional.**
-  - `queue` - the name of the queue. *[string]* **Required**
-  - `options` - optional settings. *[Object]* **Optional**
-    - `routeKey` - value for the route key to route the message with.  The value must be supplied here or in `message.event`.  The value can be `.` separated for namespacing. *[string]* **Optional**
-    - `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]*  **Optional**
-    - `source` - value attached to the header of the message to help with tracking the origination point of your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]*  **Optional**
-    - In addition to the above options, all of `amqplib`'s [configuration options](http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish) (except for `headers` and `immediate`) from its `sendToQueue` and `publish` methods can also be passed as top-level properties in the `send` options.
+  * `message` - the content being sent directly to specfied queue. *[string|Object|Buffer]* **Required**
+    * `event` - override value for the route key. The value must be supplied here or in `options.routeKey`.  The value can be `.` separated for namespacing. *[string]* **Optional.**
+  * `queue` - the name of the queue. *[string]* **Required**
+  * `options` - optional settings. *[Object]* **Optional**
+    * `routeKey` - value for the route key to route the message with.  The value must be supplied here or in `message.event`.  The value can be `.` separated for namespacing. *[string]* **Optional**
+    * `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]*  **Optional**
+    * `source` - value attached to the header of the message to help with tracking the origination point of your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]*  **Optional**
+    * In addition to the above options, all of `amqplib`'s [configuration options](http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish) (except for `headers` and `immediate`) from its `sendToQueue` and `publish` methods can also be passed as top-level properties in the `send` options.
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -698,11 +700,11 @@ Pop all messages directly off of a queue until there are no more.  Handler is ca
 
 ##### parameter(s)
 
-  - `queue` - the name of the queue. *[string]* **Required**
-  - `handler` - a handler reflects an `AsyncFunction` as `async (message, [meta, [ack]]) => {}`. *[AsyncFunction]* **Required**
-  - `options` - optional settings. *[Object]* **Optional**
-    - `get` - [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_get) are proxied through to amqplib `get`. *[Object]* **Optional**
-    - `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack]) => {}`.  *[boolean]* **Optional**
+  * `queue` - the name of the queue. *[string]* **Required**
+  * `handler` - a handler reflects an `AsyncFunction` as `async (message, [meta, [ack]]) => {}`. *[AsyncFunction]* **Required**
+  * `options` - optional settings. *[Object]* **Optional**
+    * `get` - [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_get) are proxied through to amqplib `get`. *[Object]* **Optional**
+    * `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack]) => {}`.  *[boolean]* **Optional**
 
 ```javascript
 const BunnyBus = require('bunnybus');
@@ -819,7 +821,9 @@ Rejects a message by acknowledging off the originating queue and sending to an e
 * `payload` - raw payload from an AMQP result message response. *[Object]* **Required**
 * `channelName` - the originating channel the payload came from. *[string]* **Required**
 * `errorQueue` - the destination error queue to push to. Defaults to a queue defined in [`config`](#config) *[string]* **Optional**
-* `options` - can supply AMQP specific values which is just proxied to [`sentToQueue`](https://www.squaremobius.net/amqp.node/channel_api.html#channel_sendToQueue) for the destination error queue.  A property of `reason` can be supplied which will be caught and added to the message header.  The property of `reason` is used uniformally within all rejection paths in the BunnyBus code base. *[Object]* **Required**
+* `options` - can supply AMQP specific values which is just proxied to [`sentToQueue`](https://www.squaremobius.net/amqp.node/channel_api.html#channel_sendToQueue) for the destination error queue.
+  * `reason` - can be supplied which will be caught and added to the message header.  The property of `reason` is used uniformally within all rejection paths in the BunnyBus code base. *[string]* **Optionald**
+  * `errorQueue` - the name of the queue to route the error to instead of the safe defaults. *[string]* **Optional**
 
 ```javascript
 const BunnyBus = require('bunnybus');

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -2,21 +2,22 @@
 
 module.exports = {
     buildPublishOrSendOptions: require('./buildPublishOrSendOptions'),
-    defaultConfiguration: require('./defaultConfiguration'),
-    createConnectionString: require('./createConnectionString'),
+    cleanObject: require('./cleanObject'),
     convertToBuffer: require('./convertToBuffer'),
+    createConnectionString: require('./createConnectionString'),
     createTransactionId: require('./createTransactionId'),
+    defaultConfiguration: require('./defaultConfiguration'),
     exponentialBackoff: require('./exponentialBackoff'),
     getPackageData: require('./getPackageData'),
-    isMajorCompatible: require('./isMajorCompatible'),
-    cleanObject: require('./cleanObject'),
-    parsePayload: require('./parsePayload'),
-    reduceRouteKey: require('./reduceRouteKey'),
-    validateLoggerContract: require('./validateLoggerContract'),
-    routeMatcher: require('./routeMatcher'),
     handlerMatcher: require('./handlerMatcher'),
-    isString: require('./isString'),
     intervalAsync: require('./intervalAsync'),
+    isMajorCompatible: require('./isMajorCompatible'),
+    isString: require('./isString'),
+    parsePayload: require('./parsePayload'),
+    reduceErrorQueue: require('./reduceErrorQueue'),
+    reduceRouteKey: require('./reduceRouteKey'),
     retryAsync: require('./retryAsync'),
-    timeoutAsync: require('./timeoutAsync')
+    routeMatcher: require('./routeMatcher'),
+    timeoutAsync: require('./timeoutAsync'),
+    validateLoggerContract: require('./validateLoggerContract')
 };

--- a/lib/helpers/reduceErrorQueue.js
+++ b/lib/helpers/reduceErrorQueue.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const IsString = require('./isString');
+
+const string = (value) => (IsString(value) ? value : undefined);
+
+const reduceErrorQueue = (defaultQueue, globalQueue, localQueue) => {
+    return string(localQueue) || string(globalQueue) || string(defaultQueue);
+};
+
+module.exports = reduceErrorQueue;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
+const Hoek = require('@hapi/hoek');
 const Helpers = require('./helpers');
 const Exceptions = require('./exceptions');
 const { ChannelManager, ConnectionManager, HttpClientManager, SubscriptionManager } = require('./states');
@@ -655,7 +656,11 @@ class BunnyBus extends EventEmitter {
     async _reject(payload, channelName, errorQueue, options) {
         const channelContext = await this._autoBuildChannelContext(channelName);
 
-        const queue = errorQueue || this.config.server.errorQueue;
+        const queue = Helpers.reduceErrorQueue(
+            Hoek.reach(this.config, 'errorQueue'),
+            errorQueue,
+            Hoek.reach(options, 'errorQueue')
+        );
 
         const headers = {
             transactionId: payload.properties.headers.transactionId,
@@ -666,7 +671,7 @@ class BunnyBus extends EventEmitter {
             erroredAt: new Date().toISOString(),
             retryCount: payload.properties.headers.retryCount || 0,
             bunnyBus: Helpers.getPackageData().version,
-            reason: options && options.reason
+            reason: Hoek.reach(options, 'reason')
         };
 
         const sendOptions = Helpers.buildPublishOrSendOptions(options, headers);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/tenna-llc/bunnybus"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.x",
     "amqplib": "^0.5.x",
     "set-interval-async": "^1.x",
     "superagent": "^5.x"

--- a/test/lab/helpers/reduceErrorQueue.js
+++ b/test/lab/helpers/reduceErrorQueue.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const Helpers = require('../../../lib/helpers');
+
+const { describe, before, beforeEach, after, it } = (exports.lab = Lab.script());
+const expect = Code.expect;
+
+describe('Helpers', () => {
+    describe('reduceErrorQueue', () => {
+        describe('validation', () => {
+            it('should return undefined when defaultQueue is not a string', async () => {
+                expect(Helpers.reduceErrorQueue({})).to.be.undefined();
+                expect(Helpers.reduceErrorQueue(1)).to.be.undefined();
+            });
+
+            it('should return undefined when globalQueue is not a string', async () => {
+                expect(Helpers.reduceErrorQueue(undefined, {})).to.be.undefined();
+                expect(Helpers.reduceErrorQueue(undefined, 1)).to.be.undefined();
+            });
+
+            it('should return undefined when localQueue is not a string', async () => {
+                expect(Helpers.reduceErrorQueue(undefined, undefined, {})).to.be.undefined();
+                expect(Helpers.reduceErrorQueue(undefined, undefined, 1)).to.be.undefined();
+            });
+        });
+
+        describe('priority', () => {
+            it('should return undefined when nothing is supplied', async () => {
+                expect(Helpers.reduceErrorQueue()).to.be.undefined();
+            });
+
+            it('should return localQueue when everything is supplied', async () => {
+                expect(Helpers.reduceErrorQueue('d', 'g', 'l')).to.equal('l');
+            });
+
+            it('should return localQueue when local and default queue is supplied', async () => {
+                expect(Helpers.reduceErrorQueue('d', null, 'l')).to.equal('l');
+            });
+
+            it('should return localQueue when only local queue is supplied', async () => {
+                expect(Helpers.reduceErrorQueue(null, null, 'l')).to.equal('l');
+            });
+
+            it('should return globalQueue when global and default queue is supplied', async () => {
+                expect(Helpers.reduceErrorQueue('d', 'g')).to.equal('g');
+            });
+
+            it('should return defaultQueue when only default queue is supplied', async () => {
+                expect(Helpers.reduceErrorQueue('d')).to.equal('d');
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When `reject` is used, a custom error queue can be supplied.

```javascript
async bunnyBus.subscribe('queue1`, { topic: async (msg, ack, rej) => {
    try {
        await ack();
    }
    catch(err) {
        await rej({
            reason: err.message,
            errorQueue: 'custom-error-queue'
        });
    }
}});
```

## Documentation

* This has been documented in the `subscribe` and `_reject` sections.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now that BunnyBus is gaining wider adoption at Tenna, we are seeing the need to have this customization available.  Existing apps currently route to a single global error queue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.