### PR TITLE
Interface Redesign

### DIFF
--- a/API.md
+++ b/API.md
@@ -577,7 +577,6 @@ Subscribe to messages from a given queue.
     * `disableQueueBind` - flag for disabling automatic queue binding.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* **Optional**
     * `rejectUnroutedMessages` - flag for enabling rejection for unroutable messages.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
     * `rejectPoisonMessages` - flag for enabling rejection for poison messages.  A poison queue is named by default to `<your queue name>_poison`.  More info can be found in [config](#config).  Defaults to one provided in the [config](#config).  *[boolean]* 
-    * `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
 
 ##### handlers
 
@@ -589,10 +588,10 @@ A `key` is the routeKey in RabbitMQ terminology.  `BunnyBus` specifically levera
 
 A `handler` is an asynchronous function which contains the following arity.  Order matters.
   * `message` is what was received from the bus.  The message does represent the RabbitMQ `'payload.content` buffer.  The original source of this object is from `payload.content`.
-  * `meta` is only available when `options.meta` is set to `true`.  This object will contain all payload related meta information like `payload.properties.headers`. Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.
+  * `metaData` This object will contain all payload related meta information like `payload.properties.headers`. Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `metaData.headers` object.
   * `async ack([option])` is an async function for acknowledging the message off the bus.
     * `option` - a placeholder for future optional parameters for `ack`.  High chance of deprecation.
-  * `async reject([option])` is an async function for rejecting the message off the bus to a predefined error queue.  The error queue is named by default to `<your queue name>_error`.  It will also short circuit to `error_bus` when defaults can't be found.
+  * `async rej([option])` is an async function for rejecting the message off the bus to a predefined error queue.  The error queue is named by default to `<your queue name>_error`.  It will also short circuit to `error_bus` when defaults can't be found.
     * `option` *[Object]* **Optional**
       * `reason` - A string that should describe the reason the message is being rejcted *[String]* **Optional**
       * `errorQueue` - A string for a specific error queue that the message should be routed to. *[String]* **Optional**
@@ -603,10 +602,10 @@ const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
 const handlers = {
-    route.event1 : async (message, ack, reject, requeue) => {
+    route.event1 : async ({message, metaData, ack, rej, requeue}) => {
         await ack();
     },
-    route.event2 : async (message, ack, reject, requeue) => {
+    route.event2 : async ({message, metaData, ack, rej, requeue}) => {
         if (//something not ready) {
             await requeue();
         } else {

--- a/API.md
+++ b/API.md
@@ -19,49 +19,49 @@
   - [Static Methods](#static-methods)
     - [`Singleton([config])`](#singletonconfig)
   - [Methods](#methods)
-    - [`async createExchange(name, type, [options])`](#async-createexchangename-type-options)
+    - [`async createExchange({name, type, [options]})`](#async-createexchangename-type-options)
       - [parameter(s)](#parameters)
-    - [`async deleteExchange(name, [options])`](#async-deleteexchangename-options)
+    - [`async deleteExchange({name, [options]})`](#async-deleteexchangename-options)
       - [parameter(s)](#parameters-1)
-    - [`async checkExchange(name)`](#async-checkexchangename)
+    - [`async checkExchange({name})`](#async-checkexchangename)
       - [parameter(s)](#parameters-2)
-    - [`async createQueue(name, [options])`](#async-createqueuename-options)
+    - [`async createQueue({name, [options]})`](#async-createqueuename-options)
       - [parameter(s)](#parameters-3)
     - [`async deleteQueue(name, [options])`](#async-deletequeuename-options)
       - [parameter(s)](#parameters-4)
-    - [`async checkQueue(name)`](#async-checkqueuename)
+    - [`async checkQueue({name})`](#async-checkqueuename)
       - [parameter(s)](#parameters-5)
-    - [`async purgeQueue(name)`](#async-purgequeuename)
+    - [`async purgeQueue({name})`](#async-purgequeuename)
       - [parameter(s)](#parameters-6)
-    - [`async publish(message, [options])`](#async-publishmessage-options)
+    - [`async publish({message, [options]})`](#async-publishmessage-options)
       - [parameter(s)](#parameters-7)
-    - [`async subscribe(queue, handlers, [options])`](#async-subscribequeue-handlers-options)
+    - [`async subscribe({queue, handlers, [options]})`](#async-subscribequeue-handlers-options)
       - [parameter(s)](#parameters-8)
       - [handlers](#handlers)
       - [`key`](#key)
       - [`handler`](#handler)
-    - [`async resubscribe(queue)`](#async-resubscribequeue)
+    - [`async resubscribe({queue})`](#async-resubscribequeue)
       - [parameter(s)](#parameters-9)
-    - [`async unsubscribe(queue)`](#async-unsubscribequeue)
+    - [`async unsubscribe({queue})`](#async-unsubscribequeue)
       - [parameter(s)](#parameters-10)
-    - [`await send(message, queue, [options])`](#await-sendmessage-queue-options)
+    - [`await send({message, queue, [options]})`](#await-sendmessage-queue-options)
       - [note(s)](#notes)
       - [parameter(s)](#parameters-11)
-    - [`async get(queue, [options])`](#async-getqueue-options)
+    - [`async get({queue, [options]})`](#async-getqueue-options)
       - [parameter(s)](#parameters-12)
-    - [`async getAll(queue, handler, [options])`](#async-getallqueue-handler-options)
+    - [`async getAll({queue, handler, [options]})`](#async-getallqueue-handler-options)
       - [parameter(s)](#parameters-13)
     - [`async stop()`](#async-stop)
   - [Internal-use Methods](#internal-use-methods)
-    - [`async _autoBuildChannelContext(channelName, [queue = null])`](#async-_autobuildchannelcontextchannelname-queue--null)
+    - [`async _autoBuildChannelContext({channelName, [queue = null]})`](#async-_autobuildchannelcontextchannelname-queue--null)
       - [`parameter(s)`](#parameters)
     - [`async _recoverConnection()`](#async-_recoverconnection)
-    - [`async _recoverChannel(channelName)`](#async-_recoverchannelchannelname)
-    - [`async _ack(payload, channelName, [options])`](#async-_ackpayload-channelname-options)
+    - [`async _recoverChannel({channelName})`](#async-_recoverchannelchannelname)
+    - [`async _ack({payload, channelName}, [options]})`](#async-_ackpayload-channelname-options)
       - [`parameter(s)`](#parameters-1)
-    - [`async _requeue(payload, channelName, queue, [options])`](#async-_requeuepayload-channelname-queue-options)
+    - [`async _requeue({payload, channelName, queue}, [options])`](#async-_requeuepayload-channelname-queue-options)
       - [`parameter(s)`](#parameters-2)
-    - [`async _reject(payload, channelName, [errorQueue, [options]])`](#async-_rejectpayload-channelname-errorqueue-options)
+    - [`async _reject({payload, channelName, [errorQueue]}, [options])`](#async-_rejectpayload-channelname-errorqueue-options)
       - [`parameter(s)`](#parameters-3)
   - [Events](#events)
   - [`BunnyBus.LOG_DEBUG_EVENT`](#bunnybuslog_debug_event)
@@ -422,7 +422,7 @@ const bunnyBus = BunnyBus.Singleton({ hostname : 'red-bee.cloudamqp.com' });
 
 ### Methods
 
-#### `async createExchange(name, type, [options])`
+#### `async createExchange({name, type, [options]})`
 
 Creates an exchange.
 
@@ -436,10 +436,10 @@ Creates an exchange.
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-await bunnyBus.createExchange('default-exchange', 'topic');
+await bunnyBus.createExchange({ name: 'default-exchange', type: 'topic' });
 ```
 
-#### `async deleteExchange(name, [options])`
+#### `async deleteExchange({name, [options]})`
 
 Delete an exchange.
 
@@ -452,10 +452,10 @@ Delete an exchange.
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-await bunnyBus.deleteExchange('default-exchange');
+await bunnyBus.deleteExchange({ name: 'default-exchange' });
 ```
 
-#### `async checkExchange(name)`
+#### `async checkExchange({name})`
 
 Checks if an exchange exists.  The channel closes when the exchange does not exist.
 
@@ -467,10 +467,10 @@ Checks if an exchange exists.  The channel closes when the exchange does not exi
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-await bunnyBus.checkExchange('default-exchange');
+await bunnyBus.checkExchange({ name: 'default-exchange' });
 ```
 
-#### `async createQueue(name, [options])`
+#### `async createQueue({name, [options]})`
 
 Creates a queue.
 
@@ -483,7 +483,7 @@ Creates a queue.
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-bunnyBus.createQueue('queue1');
+bunnyBus.createQueue({ name: 'queue1' });
 ```
 
 #### `async deleteQueue(name, [options])`
@@ -499,10 +499,10 @@ Delete a queue.
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-async bunnyBus.deleteQueue('queue1');
+async bunnyBus.deleteQueue({ name: 'queue1' });
 ```
 
-#### `async checkQueue(name)`
+#### `async checkQueue({name})`
 
 Checks if a queue exists.  Returns a queue info object `{ queue, messageCount, consumerCount }` when it exist.
 
@@ -514,10 +514,10 @@ Checks if a queue exists.  Returns a queue info object `{ queue, messageCount, c
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-await bunnyBus.checkQueue('queue1');
+await bunnyBus.checkQueue({ name: 'queue1' });
 ```
 
-#### `async purgeQueue(name)`
+#### `async purgeQueue({name})`
 
 Purges a queue.  Will not throw error in cases where queue does not exist.
 
@@ -529,10 +529,10 @@ Purges a queue.  Will not throw error in cases where queue does not exist.
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-await bunnyBus.purgeQueue('queue1');
+await bunnyBus.purgeQueue({ name: 'queue1' });
 ```
 
-#### `async publish(message, [options])`
+#### `async publish({message, [options]})`
 
 Publish a message onto the bus.
 
@@ -557,10 +557,10 @@ const message = {
     // other stuff you want to send
 }
 
-await bunnyBus.publish(message);
+await bunnyBus.publish({message});
 ```
 
-#### `async subscribe(queue, handlers, [options])`
+#### `async subscribe({queue, handlers, [options]})`
 
 Subscribe to messages from a given queue.
 
@@ -615,10 +615,10 @@ const handlers = {
     }
 }
 
-await bunnyBus.subscribe('queue', handlers);
+await bunnyBus.subscribe({queue: 'queue', handlers });
 ```
 
-#### `async resubscribe(queue)`
+#### `async resubscribe({queue})`
 
 Resubscribes non-active handlers to a queue.  This should be used with [`unsubscribe()`](#async-unsubscribequeue).
 
@@ -630,10 +630,10 @@ Resubscribes non-active handlers to a queue.  This should be used with [`unsubsc
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-await bunnyBus.resubscribe('queue1');
+await bunnyBus.resubscribe({ queue: 'queue1' });
 ```
 
-#### `async unsubscribe(queue)`
+#### `async unsubscribe({queue})`
 
 Unsubscribe active handlers that are listening to a queue.
 
@@ -645,10 +645,10 @@ Unsubscribe active handlers that are listening to a queue.
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-await bunnyBus.unsubscribe('queue1');
+await bunnyBus.unsubscribe({ queue: 'queue1' });
 ```
 
-#### `await send(message, queue, [options])`
+#### `await send({message, queue, [options]})`
 
 Send a message directly to a specified queue.
 
@@ -675,10 +675,10 @@ const message = {
     // other stuff you want to send
 }
 
-await bunnyBus.send(message, 'queue1');
+await bunnyBus.send({message, queue: 'queue1'});
 ```
 
-#### `async get(queue, [options])`
+#### `async get({queue, [options]})`
 
 Pop a message directly off a queue.  The payload returned is the RabbitMQ `payload` with `payload.properties` and `payload.content` in its original form.
 
@@ -691,30 +691,29 @@ Pop a message directly off a queue.  The payload returned is the RabbitMQ `paylo
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-const payload = await bunnyBus.get('queue1');
+const payload = await bunnyBus.get({ queue: 'queue1' });
 ```
 
-#### `async getAll(queue, handler, [options])`
+#### `async getAll({queue, handler, [options]})`
 
 Pop all messages directly off of a queue until there are no more.  Handler is called for each message that is popped.
 
 ##### parameter(s)
 
   * `queue` - the name of the queue. *[string]* **Required**
-  * `handler` - a handler reflects an `AsyncFunction` as `async (message, [meta, [ack]]) => {}`. *[AsyncFunction]* **Required**
+  * `handler` - a handler reflects an `AsyncFunction` as `async ({message, metaData, ack}) => {}`. *[AsyncFunction]* **Required**
   * `options` - optional settings. *[Object]* **Optional**
     * `get` - [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_get) are proxied through to amqplib `get`. *[Object]* **Optional**
-    * `meta` - allows for meta data regarding the payload to be returned.  Headers like the `createdAt` ISO string timestamp and the `transactionId` are included in the `meta.headers` object.  Turning this on will adjust the handler to be an `AsyncFunction` as `async (message, meta, [ack]) => {}`.  *[boolean]* **Optional**
 
 ```javascript
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-const handler = async (message, ack) => {
+const handler = async ({message, metaData, ack}) => {
     await ack();
 }
 
-await bunnyBus.getAll('queue1', handler);
+await bunnyBus.getAll({queue: 'queue1', handler});
 ```
 
 #### `async stop()`
@@ -732,7 +731,7 @@ await bunnyBus.stop();
 
 The following methods are available in the public API, but manual use of them is highly discouraged.
 
-#### `async _autoBuildChannelContext(channelName, [queue = null])`
+#### `async _autoBuildChannelContext({channelName, [queue = null]})`
 
 Method handles the coordination for creating a connection and channel via the [`ConnectionManager`](#connectionmanager) and [`ChannelManager`](#channelmanager).  This is also responsible for subscribing to error and close events available from the [`Connection`](#connection) and [`Channel`](#channel) context classes which proxy events from the corresponding underlying `amqplib` objects.  
 
@@ -745,7 +744,7 @@ Method handles the coordination for creating a connection and channel via the [`
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-const channelContext = await bunnyBus._autoBuildChannelContext(channelForQueue1);
+const channelContext = await bunnyBus._autoBuildChannelContext({ channelName: 'channelForQueue1' });
 // output : { name, queue, connectionContext, channelOptions, lock, channel }
 ```
 
@@ -762,7 +761,7 @@ const bunnyBus = new BunnyBus();
 await bunnyBus._recoverConnection();
 ```
 
-#### `async _recoverChannel(channelName)`
+#### `async _recoverChannel({channelName})`
 
 Auto retry mechanism to restore a specific channel and attached connection that was closed.  When failure happens, an invocation to `process.exit(1)` will be done.  This is invoked internally through event handlers listening to channel events.  This will not revive subscribed queues that are in block state registered through the [`SubscriptionManager`](#subscriptionmanager)
 
@@ -772,10 +771,10 @@ const bunnyBus = new BunnyBus();
 
 // something bad happened
 
-await bunnyBus._recoverChannel(channelName);
+await bunnyBus._recoverChannel({channelName});
 ```
 
-#### `async _ack(payload, channelName, [options])`
+#### `async _ack({payload, channelName}, [options]})`
 
 The acknowledge method for removing a message off the queue.  Mainly used in handlers through `bind()` parameter injection for methods like [`getAll()`](#async-getallqueue-handler-options) and [`subscribe`](#async-subscribequeue-handlers-options).
 
@@ -789,11 +788,24 @@ The acknowledge method for removing a message off the queue.  Mainly used in han
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-const payload = await bunnyBus.getAll('queue1');
-await bunnyBus.ack(payload, 'channelForQueue1');
+const payload = await bunnyBus.get({ queue: 'queue1' });
+await bunnyBus.ack({ payload, channelName: 'channelForQueue1' });
 ```
 
-#### `async _requeue(payload, channelName, queue, [options])`
+When supplied through the handler
+
+```javascript
+const BunnyBus = require('bunnybus');
+const bunnyBus = new BunnyBus();
+
+await bunnyBus.subscribe({ queue: 'queue1' : handlers: {
+    'topicA': async (message, ack, rej, requeue) => {
+        ack();
+    }
+}});
+```
+
+#### `async _requeue({payload, channelName, queue}, [options])`
 
 Requeues message to any queue while it acknowledges the payload off of the original.  This method does not push the message back to the original queue in the front position.  It will put the message to any desired queue in the back position.  Mainly used in handlers through `bind()` parameter injection for methods like [`getAll()`](#async-getallqueue-handler-options) and [`subscribe()`](#async-subscribequeue-handlers-options).
 
@@ -808,11 +820,24 @@ Requeues message to any queue while it acknowledges the payload off of the origi
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-const payload = await bunnyBus.getAll('queue1');
-await bunnyBus.requeue(payload, 'channelForQueue1', 'queue1');
+const payload = await bunnyBus.get({ queue: 'queue1' });
+await bunnyBus.requeue({ payload, channelName: 'channelForQueue1', queue: 'queue1' });
 ```
 
-#### `async _reject(payload, channelName, [errorQueue, [options]])`
+When supplied through the handler
+
+```javascript
+const BunnyBus = require('bunnybus');
+const bunnyBus = new BunnyBus();
+
+await bunnyBus.subscribe({ queue: 'queue1' : handlers: {
+    'topicA': async (message, ack, rej, requeue) => {
+        requeue({ reason: 'wait condition not met' });
+    }
+}});
+```
+
+#### `async _reject({payload, channelName, [errorQueue]}, [options])`
 
 Rejects a message by acknowledging off the originating queue and sending to an error queue of choice.  Mainly used in handlers through `bind()` parameter injection for methods like [`getAll()`](#async-getallqueue-handler-options) and [`subscribe()`](#async-subscribequeue-handlers-options).
 
@@ -829,8 +854,21 @@ Rejects a message by acknowledging off the originating queue and sending to an e
 const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
-const payload = await bunnyBus.getAll('queue1');
-await bunnyBus.reject(payload, 'channelForQueue1', 'queue1_error', { reason: 'some unforeseen failure' });
+const payload = await bunnyBus.get({ queue: 'queue1' });
+await bunnyBus.reject({payload, channelName: 'channelForQueue1', errorQueue: 'queue1_error'}, { reason: 'some unforeseen failure' });
+```
+
+When supplied through the handler
+
+```javascript
+const BunnyBus = require('bunnybus');
+const bunnyBus = new BunnyBus();
+
+await bunnyBus.subscribe({ queue: 'queue1' : handlers: {
+    'topicA': async (message, ack, rej, requeue) => {
+        rej({ reason: 'error encountered', errorQueue: 'error-queue-shard-5' });
+    }
+}});
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ const bunnyBus = new BunnyBus();
 
 //create a subscription
 await bunnyBus.subscribe('queue1', { 
-    'create-event' : async (message, ack) => {
+    'create-event' : async ({message, ack}) => {
         console.log(message.comment);
         await ack();
     }}
 );
 
 //publish to the above subscription
-await bunnyBus.publish({ event : 'create-event', comment : 'hello world!' });
+const payload = { event : 'create-event', comment : 'hello world!' }
+
+await bunnyBus.publish({ message: payload });
 
 );
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -391,7 +391,6 @@ class BunnyBus extends EventEmitter {
 
     async getAll({ queue, handler, options }) {
         const getOptions = options && options.get;
-        const meta = options && options.meta;
         const channelName = BunnyBus.QUEUE_CHANNEL_NAME(queue);
 
         let processing = true;
@@ -403,18 +402,12 @@ class BunnyBus extends EventEmitter {
                 const parsedPayload = Helpers.parsePayload(payload);
 
                 // Not currently handling poison message unlike subscribe
-                if (meta) {
-                    await handler({
-                        message: parsedPayload.message,
-                        metaData: parsedPayload.metaData,
-                        ack: this._ack.bind(this, { payload, channelName })
-                    });
-                } else {
-                    await handler({
-                        message: parsedPayload.message,
-                        ack: this._ack.bind(this, { payload, channelName })
-                    });
-                }
+
+                await handler({
+                    message: parsedPayload.message,
+                    metaData: parsedPayload.metaData,
+                    ack: this._ack.bind(this, { payload, channelName })
+                });
             } else {
                 processing = false;
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -201,9 +201,11 @@ class BunnyBus extends EventEmitter {
         return Helpers.createConnectionString(this.config);
     }
 
-    async createExchange(name, type, options) {
+    async createExchange({ name, type, options }) {
         if (!this.config.disableExchangeCreate) {
-            const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            const channelContext = await this._autoBuildChannelContext({
+                channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME()
+            });
 
             //type : (direct, fanout, header, topic)
             return await channelContext.channel.assertExchange(
@@ -214,18 +216,16 @@ class BunnyBus extends EventEmitter {
         }
     }
 
-    async deleteExchange(name, options) {
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+    async deleteExchange({ name, options }) {
+        const channelContext = await this._autoBuildChannelContext({ channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME() });
 
         return await channelContext.channel.deleteExchange(name, options);
     }
 
-    async checkExchange(name) {
+    async checkExchange({ name }) {
         let result = undefined;
-        this.httpC;
 
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
-
+        const channelContext = await this._autoBuildChannelContext({ channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME() });
         const promise = new Promise((resolve) => {
             channelContext.once(ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, resolve);
         });
@@ -248,15 +248,17 @@ class BunnyBus extends EventEmitter {
                 throw err;
             }
         } finally {
-            await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            await this._autoBuildChannelContext({ channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME() });
         }
 
         return result;
     }
 
-    async createQueue(name, options) {
+    async createQueue({ name, options }) {
         if (!this.config.disableQueueCreate) {
-            const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            const channelContext = await this._autoBuildChannelContext({
+                channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME()
+            });
 
             return await channelContext.channel.assertQueue(
                 name,
@@ -265,10 +267,10 @@ class BunnyBus extends EventEmitter {
         }
     }
 
-    async purgeQueue(name) {
+    async purgeQueue({ name }) {
         let result = false;
 
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+        const channelContext = await this._autoBuildChannelContext({ channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME() });
 
         const promise = new Promise((resolve) => {
             channelContext.once(ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, resolve);
@@ -293,19 +295,19 @@ class BunnyBus extends EventEmitter {
                 throw err;
             }
         } finally {
-            await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            await this._autoBuildChannelContext({ channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME() });
         }
 
         return result;
     }
 
-    async deleteQueue(name, options) {
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+    async deleteQueue({ name, options }) {
+        const channelContext = await this._autoBuildChannelContext({ channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME() });
 
         return await channelContext.channel.deleteQueue(name, options);
     }
 
-    async checkQueue(name) {
+    async checkQueue({ name }) {
         let result = undefined;
 
         const httpClient = await this.httpClients.create(BunnyBus.DEFAULT_HTTP_CLIENT_NAME, this.config);
@@ -319,7 +321,9 @@ class BunnyBus extends EventEmitter {
                 }
             }
         } else {
-            const channelContext = await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+            const channelContext = await this._autoBuildChannelContext({
+                channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME()
+            });
 
             const promise = new Promise((resolve) => {
                 channelContext.once(ChannelManager.AMQP_CHANNEL_CLOSE_EVENT, resolve);
@@ -343,22 +347,22 @@ class BunnyBus extends EventEmitter {
                     throw err;
                 }
             } finally {
-                await this._autoBuildChannelContext(BunnyBus.MANAGEMENT_CHANNEL_NAME());
+                await this._autoBuildChannelContext({ channelName: BunnyBus.MANAGEMENT_CHANNEL_NAME() });
             }
         }
 
         return result;
     }
 
-    async send(message, queue, options) {
+    async send({ message, queue, options }) {
         const routeKey = Helpers.reduceRouteKey(null, options, message);
         const source = options && options.source;
 
         const convertedMessage = Helpers.convertToBuffer(message);
         const transactionId = options && options.transactionId ? options.transactionId : Helpers.createTransactionId();
         const [channelContext] = await Promise.all([
-            this._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue), queue),
-            this.createQueue(queue)
+            this._autoBuildChannelContext({ channelName: BunnyBus.QUEUE_CHANNEL_NAME(queue), queue }),
+            this.createQueue({ name: queue })
         ]);
 
         const headers = {
@@ -376,13 +380,16 @@ class BunnyBus extends EventEmitter {
         await channelContext.channel.waitForConfirms();
     }
 
-    async get(queue, options) {
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue), queue);
+    async get({ queue, options }) {
+        const channelContext = await this._autoBuildChannelContext({
+            channelName: BunnyBus.QUEUE_CHANNEL_NAME(queue),
+            queue
+        });
 
         return await channelContext.channel.get(queue, options);
     }
 
-    async getAll(queue, handler, options) {
+    async getAll({ queue, handler, options }) {
         const getOptions = options && options.get;
         const meta = options && options.meta;
         const channelName = BunnyBus.QUEUE_CHANNEL_NAME(queue);
@@ -390,20 +397,23 @@ class BunnyBus extends EventEmitter {
         let processing = true;
 
         do {
-            const payload = await this.get(queue, getOptions);
+            const payload = await this.get({ queue, options: getOptions });
 
             if (payload) {
                 const parsedPayload = Helpers.parsePayload(payload);
 
                 // Not currently handling poison message unlike subscribe
                 if (meta) {
-                    await handler(
-                        parsedPayload.message,
-                        parsedPayload.metaData,
-                        this._ack.bind(this, payload, channelName)
-                    );
+                    await handler({
+                        message: parsedPayload.message,
+                        metaData: parsedPayload.metaData,
+                        ack: this._ack.bind(this, { payload, channelName })
+                    });
                 } else {
-                    await handler(parsedPayload.message, this._ack.bind(this, payload, channelName));
+                    await handler({
+                        message: parsedPayload.message,
+                        ack: this._ack.bind(this, { payload, channelName })
+                    });
                 }
             } else {
                 processing = false;
@@ -411,7 +421,7 @@ class BunnyBus extends EventEmitter {
         } while (processing);
     }
 
-    async publish(message, options) {
+    async publish({ message, options }) {
         const globalExchange = (options && options.globalExchange) || this.config.globalExchange;
         const routeKey = Helpers.reduceRouteKey(null, options, message);
         const source = options && options.source;
@@ -424,8 +434,8 @@ class BunnyBus extends EventEmitter {
         const convertedMessage = Helpers.convertToBuffer(message);
         const transactionId = options && options.transactionId ? options.transactionId : Helpers.createTransactionId();
         const [channelContext] = await Promise.all([
-            this._autoBuildChannelContext(BunnyBus.PUBLISH_CHANNEL_NAME()),
-            this.createExchange(globalExchange, 'topic', null)
+            this._autoBuildChannelContext({ channelName: BunnyBus.PUBLISH_CHANNEL_NAME() }),
+            this.createExchange({ name: globalExchange, type: 'topic' })
         ]);
 
         const headers = {
@@ -446,7 +456,7 @@ class BunnyBus extends EventEmitter {
         this.emit(BunnyBus.PUBLISHED_EVENT, publishOptions, message);
     }
 
-    async subscribe(queue, handlers, options) {
+    async subscribe({ queue, handlers, options }) {
         if (this.subscriptions.contains(queue)) {
             throw new Exceptions.SubscriptionExistError(queue);
         }
@@ -483,9 +493,12 @@ class BunnyBus extends EventEmitter {
         const meta = options && options.meta;
         const channelName = BunnyBus.QUEUE_CHANNEL_NAME(queue);
 
-        const channelContext = await this._autoBuildChannelContext(channelName, queue);
+        const channelContext = await this._autoBuildChannelContext({ channelName, queue });
 
-        await Promise.all([this.createQueue(queue, queueOptions), this.createExchange(globalExchange, 'topic', null)]);
+        await Promise.all([
+            this.createQueue({ name: queue, options: queueOptions }),
+            this.createExchange({ name: globalExchange, type: 'topic' })
+        ]);
 
         if (!disableQueueBind) {
             await Promise.all(
@@ -512,7 +525,7 @@ class BunnyBus extends EventEmitter {
                         ) {
                             const reason = 'message not of BunnyBus origin';
                             this.logger.warn(reason);
-                            await this._reject(payload, channelName, errorQueue, { reason });
+                            await this._reject({ payload, channelName, errorQueue }, { reason });
                         }
                         // check for `bunnyBus`:<version> semver
                         else if (
@@ -522,7 +535,7 @@ class BunnyBus extends EventEmitter {
                         ) {
                             const reason = `message came from older bunnyBus version (${payload.properties.headers.bunnyBus})`;
                             this.logger.warn(reason);
-                            await this._reject(payload, channelName, errorQueue, { reason });
+                            await this._reject({ payload, channelName, errorQueue }, { reason });
                         } else if (currentRetryCount < maxRetryCount) {
                             matchedHandlers.forEach(async (matchedHandler) => {
                                 this._dispatchers[this.config.dispatchType].push(queue, async () => {
@@ -532,35 +545,40 @@ class BunnyBus extends EventEmitter {
                                         parsedPayload.message
                                     );
                                     if (meta) {
-                                        await matchedHandler(
-                                            parsedPayload.message,
-                                            parsedPayload.metaData,
-                                            this._ack.bind(this, payload, channelName),
-                                            this._reject.bind(this, payload, channelName, errorQueue),
-                                            this._requeue.bind(this, payload, channelName, queue, {
-                                                routeKey
+                                        await matchedHandler({
+                                            message: parsedPayload.message,
+                                            metaData: parsedPayload.metaData,
+                                            ack: this._ack.bind(this, { payload, channelName }),
+                                            rej: this._reject.bind(this, { payload, channelName, errorQueue }),
+                                            requeue: this._requeue.bind(this, {
+                                                payload,
+                                                channelName,
+                                                queue,
+                                                options: {
+                                                    routeKey
+                                                }
                                             })
-                                        );
+                                        });
                                     } else {
-                                        await matchedHandler(
-                                            parsedPayload.message,
-                                            this._ack.bind(this, payload, channelName),
-                                            this._reject.bind(this, payload, channelName, errorQueue),
-                                            this._requeue.bind(this, payload, channelName, queue)
-                                        );
+                                        await matchedHandler({
+                                            message: parsedPayload.message,
+                                            ack: this._ack.bind(this, { payload, channelName }),
+                                            rej: this._reject.bind(this, { payload, channelName, errorQueue }),
+                                            requeue: this._requeue.bind(this, { payload, channelName, queue })
+                                        });
                                     }
                                 });
                             });
                         } else {
                             const reason = `message passed retry limit of ${maxRetryCount} for routeKey (${routeKey})`;
                             this.logger.warn(reason);
-                            await this._reject(payload, channelName, errorQueue, { reason });
+                            await this._reject({ payload, channelName, errorQueue }, { reason });
                         }
                     } else {
                         const reason = `message consumed with no matching routeKey (${routeKey}) handler`;
                         this.logger.warn(reason);
                         if (rejectUnroutedMessages) {
-                            await this._reject(payload, channelName, errorQueue, { reason });
+                            await this._reject({ payload, channelName, errorQueue }, { reason });
                         } else {
                             // acking this directly to channel so events don't fire
                             await channelContext.channel.ack(payload);
@@ -570,7 +588,7 @@ class BunnyBus extends EventEmitter {
                     const reason = `corrupted payload content intercepted`;
                     this.logger.warn(reason);
                     if (rejectPoisonMessages) {
-                        await this._reject(payload, channelName, poisonQueue, { reason });
+                        await this._reject({ payload, channelName, errorQueue: poisonQueue }, { reason });
                     } else {
                         // acking this directly to channel so events don't fire
                         await channelContext.channel.ack(payload);
@@ -585,8 +603,8 @@ class BunnyBus extends EventEmitter {
         }
     }
 
-    async unsubscribe(queue) {
-        const channelContext = await this._autoBuildChannelContext(BunnyBus.QUEUE_CHANNEL_NAME(queue));
+    async unsubscribe({ queue }) {
+        const channelContext = await this._autoBuildChannelContext({ channelName: BunnyBus.QUEUE_CHANNEL_NAME(queue) });
 
         if (this.subscriptions.contains(queue)) {
             await channelContext.channel.cancel(this.subscriptions.get(queue).consumerTag);
@@ -595,14 +613,14 @@ class BunnyBus extends EventEmitter {
         }
     }
 
-    async resubscribe(queue) {
+    async resubscribe({ queue }) {
         if (
             this.subscriptions.contains(queue, false) &&
             !this.subscriptions.contains(queue, true) &&
             !this.subscriptions.isBlocked(queue)
         ) {
             const { handlers, options } = this.subscriptions.get(queue);
-            await this.subscribe(queue, handlers, options);
+            await this.subscribe({ queue, handlers, options });
         }
     }
 
@@ -613,8 +631,8 @@ class BunnyBus extends EventEmitter {
     }
 
     //options to store calling module, queue name
-    async _ack(payload, channelName, options) {
-        const channelContext = await this._autoBuildChannelContext(channelName);
+    async _ack({ payload, channelName, options }) {
+        const channelContext = await this._autoBuildChannelContext({ channelName });
 
         await channelContext.channel.ack(payload);
 
@@ -624,8 +642,8 @@ class BunnyBus extends EventEmitter {
         this.emit(BunnyBus.MESSAGE_ACKED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }
 
-    async _requeue(payload, channelName, queue, options) {
-        const channelContext = await this._autoBuildChannelContext(channelName);
+    async _requeue({ payload, channelName, queue, options }) {
+        const channelContext = await this._autoBuildChannelContext({ channelName });
 
         const routeKey = Helpers.reduceRouteKey(payload, options);
 
@@ -653,8 +671,8 @@ class BunnyBus extends EventEmitter {
         this.emit(BunnyBus.MESSAGE_REQUEUED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }
 
-    async _reject(payload, channelName, errorQueue, options) {
-        const channelContext = await this._autoBuildChannelContext(channelName);
+    async _reject({ payload, channelName, errorQueue }, options) {
+        const channelContext = await this._autoBuildChannelContext({ channelName });
 
         const queue = Helpers.reduceErrorQueue(
             Hoek.reach(this.config, 'errorQueue'),
@@ -676,7 +694,7 @@ class BunnyBus extends EventEmitter {
 
         const sendOptions = Helpers.buildPublishOrSendOptions(options, headers);
 
-        await this.createQueue(queue);
+        await this.createQueue({ name: queue });
         await channelContext.channel.sendToQueue(queue, payload.content, sendOptions);
         await channelContext.channel.waitForConfirms();
         await channelContext.channel.ack(payload);
@@ -692,7 +710,7 @@ class BunnyBus extends EventEmitter {
         this.emit(BunnyBus.MESSAGE_REJECTED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }
 
-    async _autoBuildChannelContext(channelName, queue = null) {
+    async _autoBuildChannelContext({ channelName, queue = null }) {
         let connectionContext = undefined;
         let channelContext = this.channels.get(channelName);
 
@@ -755,7 +773,7 @@ class BunnyBus extends EventEmitter {
 
                     if (!this.subscriptions.isBlocked(queue)) {
                         this.subscriptions.clear(queue);
-                        await this.subscribe(queue, handlers, options);
+                        await this.subscribe({ queue, handlers, options });
                     }
                 }
             } catch (err) {
@@ -773,7 +791,7 @@ class BunnyBus extends EventEmitter {
         this.logger.info(`blocking queue ${queue}`);
 
         try {
-            await this.unsubscribe(queue);
+            await this.unsubscribe({ queue });
         } catch (err) {
             err.bunnyBusMessage = 'blocked event handling failed';
             this.logger.error(err);
@@ -786,7 +804,7 @@ class BunnyBus extends EventEmitter {
         this.logger.info(`unblocking queue ${queue}`);
 
         try {
-            await this.subscribe(queue, subscription.handlers, subscription.options);
+            await this.subscribe({ queue, handlers: subscription.handlers, options: subscription.options });
         } catch (err) {
             err.bunnyBusMessage = 'unblocked event handling failed';
             this.logger.error(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -483,7 +483,6 @@ class BunnyBus extends EventEmitter {
             options && options.hasOwnProperty('rejectPoisonMessages')
                 ? options.rejectPoisonMessages
                 : this.config.rejectPoisonMessages;
-        const meta = options && options.meta;
         const channelName = BunnyBus.QUEUE_CHANNEL_NAME(queue);
 
         const channelContext = await this._autoBuildChannelContext({ channelName, queue });
@@ -537,26 +536,18 @@ class BunnyBus extends EventEmitter {
                                         parsedPayload.metaData,
                                         parsedPayload.message
                                     );
-                                    if (meta) {
-                                        await matchedHandler({
-                                            message: parsedPayload.message,
-                                            metaData: parsedPayload.metaData,
-                                            ack: this._ack.bind(this, { payload, channelName }),
-                                            rej: this._reject.bind(this, { payload, channelName, errorQueue }),
-                                            requeue: this._requeue.bind(this, {
-                                                payload,
-                                                channelName,
-                                                queue
-                                            })
-                                        });
-                                    } else {
-                                        await matchedHandler({
-                                            message: parsedPayload.message,
-                                            ack: this._ack.bind(this, { payload, channelName }),
-                                            rej: this._reject.bind(this, { payload, channelName, errorQueue }),
-                                            requeue: this._requeue.bind(this, { payload, channelName, queue })
-                                        });
-                                    }
+
+                                    await matchedHandler({
+                                        message: parsedPayload.message,
+                                        metaData: parsedPayload.metaData,
+                                        ack: this._ack.bind(this, { payload, channelName }),
+                                        rej: this._reject.bind(this, { payload, channelName, errorQueue }),
+                                        requeue: this._requeue.bind(this, {
+                                            payload,
+                                            channelName,
+                                            queue
+                                        })
+                                    });
                                 });
                             });
                         } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -612,7 +612,7 @@ class BunnyBus extends EventEmitter {
     }
 
     //options to store calling module, queue name
-    async _ack({ payload, channelName, options }) {
+    async _ack({ payload, channelName }, options) {
         const channelContext = await this._autoBuildChannelContext({ channelName });
 
         await channelContext.channel.ack(payload);
@@ -623,7 +623,7 @@ class BunnyBus extends EventEmitter {
         this.emit(BunnyBus.MESSAGE_ACKED_EVENT, parsedPayload.metaData, parsedPayload.message);
     }
 
-    async _requeue({ payload, channelName, queue, options }) {
+    async _requeue({ payload, channelName, queue }, options) {
         const channelContext = await this._autoBuildChannelContext({ channelName });
 
         const routeKey = Helpers.reduceRouteKey(payload, options);
@@ -737,12 +737,12 @@ class BunnyBus extends EventEmitter {
     async _recoverConnection() {
         for (const { name, queue } of this.channels.list()) {
             if (queue) {
-                await this._recoverChannel(name);
+                await this._recoverChannel({ channelName: name });
             }
         }
     }
 
-    async _recoverChannel(channelName) {
+    async _recoverChannel({ channelName }) {
         if (!this._state.recoveryLock) {
             this._state.recoveryLock = true;
 
@@ -819,7 +819,7 @@ class BunnyBus extends EventEmitter {
 
         try {
             this.emit(BunnyBus.RECOVERING_CHANNEL_EVENT, context.name);
-            await this._recoverChannel(context.name);
+            await this._recoverChannel({ channelName: context.name });
             this.emit(BunnyBus.RECOVERED_CHANNEL_EVENT, context.name);
         } catch (err) {}
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -553,10 +553,7 @@ class BunnyBus extends EventEmitter {
                                             requeue: this._requeue.bind(this, {
                                                 payload,
                                                 channelName,
-                                                queue,
-                                                options: {
-                                                    routeKey
-                                                }
+                                                queue
                                             })
                                         });
                                     } else {

--- a/test/jest/cleanup.test.js
+++ b/test/jest/cleanup.test.js
@@ -24,7 +24,7 @@ describe('BunnyBus', () => {
         const messageBuffer = Buffer.from(messageString);
 
         beforeAll(async () => {
-            channelContext = await instance._autoBuildChannelContext(baseChannelName);
+            channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
             await Promise.all([
                 channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -52,7 +52,7 @@ describe('BunnyBus', () => {
                     resolve();
                 };
 
-                await instance.subscribe(baseQueueName, handlers);
+                await instance.subscribe({ queue: baseQueueName, handlers });
                 await instance.publish(messageObject);
             });
         });

--- a/test/jest/cleanup.test.js
+++ b/test/jest/cleanup.test.js
@@ -17,11 +17,8 @@ describe('BunnyBus', () => {
         const baseChannelName = 'bunnybus-jest';
         const baseQueueName = 'test-jest-queue';
         const baseErrorQueueName = `${baseQueueName}_error`;
-        const publishOptions = { routeKey: 'a.b' };
-        const subscribeOptionsWithMeta = { meta: true };
         const messageObject = { event: 'a.b', name: 'bunnybus' };
         const messageString = 'bunnybus';
-        const messageBuffer = Buffer.from(messageString);
 
         beforeAll(async () => {
             channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
@@ -46,14 +43,14 @@ describe('BunnyBus', () => {
         it('should consume message (Object) from queue and acknowledge off', async () => {
             return new Promise(async (resolve) => {
                 const handlers = {};
-                handlers[messageObject.event] = async (consumedMessage, ack) => {
+                handlers[messageObject.event] = async ({ message: consumedMessage, ack }) => {
                     expect(consumedMessage).toEqual(messageObject);
                     await ack();
                     resolve();
                 };
 
                 await instance.subscribe({ queue: baseQueueName, handlers });
-                await instance.publish(messageObject);
+                await instance.publish({ message: messageObject });
             });
         });
     });

--- a/test/lab/BunnyBus/_ack.js
+++ b/test/lab/BunnyBus/_ack.js
@@ -30,7 +30,7 @@ describe('BunnyBus', () => {
             const pattern = 'a';
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 connectionContext = channelContext.connectionContext;
 
                 await Promise.all([
@@ -56,10 +56,10 @@ describe('BunnyBus', () => {
             it('should ack a message off the queue', async () => {
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        await instance.publish(message);
-                        const payload = await instance.get(baseQueueName);
+                        await instance.publish({ message });
+                        const payload = await instance.get({ queue: baseQueueName });
 
-                        await instance._ack(payload, BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName));
+                        await instance._ack({ payload, channelName: BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName) });
                         const result = await channelContext.channel.checkQueue(baseQueueName);
 
                         expect(result.queue).to.be.equal(baseQueueName);
@@ -74,12 +74,12 @@ describe('BunnyBus', () => {
             it('should not error when connection does not pre-exist', async () => {
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        await instance.publish(message);
-                        const payload = await instance.get(baseQueueName);
+                        await instance.publish({ message });
+                        const payload = await instance.get({ queue: baseQueueName });
 
                         await connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
 
-                        await instance._ack(payload, BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName));
+                        await instance._ack({ payload, channelName: BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName) });
                     },
                     connectionContext,
                     channelContext,
@@ -90,12 +90,12 @@ describe('BunnyBus', () => {
             it('should not error when channel does not pre-exist', async () => {
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        await instance.publish(message);
-                        const payload = await instance.get(baseQueueName);
+                        await instance.publish({ message });
+                        const payload = await instance.get({ queue: baseQueueName });
 
                         await channelManager.close(BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName));
 
-                        await instance._ack(payload, BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName));
+                        await instance._ack({ payload, channelName: BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName) });
                     },
                     connectionContext,
                     channelContext,

--- a/test/lab/BunnyBus/_autoBuildChannelContext.js
+++ b/test/lab/BunnyBus/_autoBuildChannelContext.js
@@ -50,7 +50,7 @@ describe('BunnyBus', () => {
                 });
 
                 it('should establish a new connection and channel when none exist', async () => {
-                    const result = await instance._autoBuildChannelContext(baseChannelName);
+                    const result = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                     expect(result).to.exist();
                     expect(result.channel).to.exist();
@@ -60,8 +60,8 @@ describe('BunnyBus', () => {
 
                 it('should return the same channel context when called concurrently', async () => {
                     const [result1, result2] = await Promise.all([
-                        instance._autoBuildChannelContext(baseChannelName),
-                        instance._autoBuildChannelContext(baseChannelName)
+                        instance._autoBuildChannelContext({ channelName: baseChannelName }),
+                        instance._autoBuildChannelContext({ channelName: baseChannelName })
                     ]);
 
                     expect(result1).to.exist();
@@ -70,8 +70,8 @@ describe('BunnyBus', () => {
                 });
 
                 it('should return the same channel context when called sequentially', async () => {
-                    const result1 = await instance._autoBuildChannelContext(baseChannelName);
-                    const result2 = await instance._autoBuildChannelContext(baseChannelName);
+                    const result1 = await instance._autoBuildChannelContext({ channelName: baseChannelName });
+                    const result2 = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                     expect(result1).to.exist();
                     expect(result2).to.exist();
@@ -104,7 +104,7 @@ describe('BunnyBus', () => {
                 });
 
                 it('should establish a new channel context when none exist', async () => {
-                    const result = await instance._autoBuildChannelContext(baseChannelName);
+                    const result = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                     expect(result).to.exist();
                     expect(result.channel).to.exist();
@@ -116,7 +116,7 @@ describe('BunnyBus', () => {
                 it('should establish a new channel context when connection is closed', async () => {
                     await connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
 
-                    const result = await instance._autoBuildChannelContext(baseChannelName);
+                    const result = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                     expect(result).to.exist();
                     expect(result.channel).to.exist();
@@ -168,7 +168,7 @@ describe('BunnyBus', () => {
                     expect(connectionContext.connection).to.be.undefined();
                     expect(channelContext.channel).to.be.undefined();
 
-                    const result = await instance._autoBuildChannelContext(baseChannelName);
+                    const result = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                     expect(result).to.exist();
                     expect(result.channel).to.exist();
@@ -183,7 +183,7 @@ describe('BunnyBus', () => {
                     expect(connectionContext.connection).to.exist();
                     expect(channelContext.channel).to.be.undefined();
 
-                    const result = await instance._autoBuildChannelContext(baseChannelName);
+                    const result = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                     expect(result).to.exist();
                     expect(result.channel).to.exist();

--- a/test/lab/BunnyBus/checkExchange.js
+++ b/test/lab/BunnyBus/checkExchange.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
             const baseExchangeName = 'test-exchange';
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 connectionContext = channelContext.connectionContext;
 
                 await channelContext.channel.deleteExchange(baseExchangeName);
@@ -42,7 +42,7 @@ describe('BunnyBus', () => {
             it('should be undefined when exchange does not exist', async () => {
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        const result1 = await instance.checkExchange(baseExchangeName);
+                        const result1 = await instance.checkExchange({ name: baseExchangeName });
                         const result2 = instance.channels.get(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
                         expect(result1).to.be.undefined();
@@ -63,7 +63,7 @@ describe('BunnyBus', () => {
 
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        const result = await instance.checkExchange(baseExchangeName);
+                        const result = await instance.checkExchange({ name: baseExchangeName });
 
                         expect(result).to.exist().and.to.be.an.object();
                     },
@@ -83,7 +83,7 @@ describe('BunnyBus', () => {
 
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        await expect(instance.checkExchange(baseExchangeName)).to.not.reject();
+                        await expect(instance.checkExchange({ name: baseExchangeName })).to.not.reject();
                     },
                     connectionContext,
                     channelContext,
@@ -101,7 +101,7 @@ describe('BunnyBus', () => {
 
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        await expect(instance.checkExchange(baseExchangeName)).to.not.reject();
+                        await expect(instance.checkExchange({ name: baseExchangeName })).to.not.reject();
                     },
                     connectionContext,
                     channelContext,

--- a/test/lab/BunnyBus/checkQueue.js
+++ b/test/lab/BunnyBus/checkQueue.js
@@ -36,7 +36,7 @@ describe('BunnyBus', () => {
                     connectionManager = instance.connections;
                     channelManager = instance.channels;
 
-                    channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                    channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                     connectionContext = channelContext.connectionContext;
 
                     await channelContext.channel.deleteQueue(baseQueueName);
@@ -50,7 +50,7 @@ describe('BunnyBus', () => {
                 it('should be undefined when queue does not exist', async () => {
                     await Assertions.autoRecoverChannel(
                         async () => {
-                            const result1 = await instance.checkQueue(baseQueueName);
+                            const result1 = await instance.checkQueue({ name: baseQueueName });
                             const result2 = instance.channels.get(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
                             expect(result1).to.be.undefined();
@@ -67,7 +67,7 @@ describe('BunnyBus', () => {
 
                     await Assertions.autoRecoverChannel(
                         async () => {
-                            const result = await instance.checkQueue(baseQueueName);
+                            const result = await instance.checkQueue({ name: baseQueueName });
 
                             expect(result).to.exist().and.to.be.an.object().and.to.contain({
                                 queue: baseQueueName,
@@ -87,7 +87,7 @@ describe('BunnyBus', () => {
 
                     await Assertions.autoRecoverChannel(
                         async () => {
-                            await expect(instance.checkQueue(baseQueueName)).to.not.reject();
+                            await expect(instance.checkQueue({ name: baseQueueName })).to.not.reject();
                         },
                         connectionContext,
                         channelContext,
@@ -101,7 +101,7 @@ describe('BunnyBus', () => {
 
                     await Assertions.autoRecoverChannel(
                         async () => {
-                            await expect(instance.checkQueue(baseQueueName)).to.not.reject();
+                            await expect(instance.checkQueue({ name: baseQueueName })).to.not.reject();
                         },
                         connectionContext,
                         channelContext,
@@ -118,7 +118,7 @@ describe('BunnyBus', () => {
                     connectionManager = instance.connections;
                     channelManager = instance.channels;
 
-                    channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                    channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                     connectionContext = channelContext.connectionContext;
 
                     await channelContext.channel.deleteQueue(baseQueueName);
@@ -129,7 +129,7 @@ describe('BunnyBus', () => {
                 });
 
                 it('should be undefined when queue does not exist', async () => {
-                    const result1 = await instance.checkQueue(baseQueueName);
+                    const result1 = await instance.checkQueue({ name: baseQueueName });
                     const result2 = instance.channels.get(BunnyBus.MANAGEMENT_CHANNEL_NAME());
 
                     expect(result1).to.be.undefined();
@@ -139,7 +139,7 @@ describe('BunnyBus', () => {
                 it('should return queue info when queue does exist', async () => {
                     await channelContext.channel.assertQueue(baseQueueName, BunnyBus.DEFAULT_QUEUE_CONFIGURATION);
 
-                    const result = await instance.checkQueue(baseQueueName);
+                    const result = await instance.checkQueue({ name: baseQueueName });
 
                     expect(result).to.exist().and.to.be.an.object().and.to.contain({
                         queue: baseQueueName,

--- a/test/lab/BunnyBus/createExchange.js
+++ b/test/lab/BunnyBus/createExchange.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
             const baseExchangeName = 'test-exchange';
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 connectionContext = channelContext.connectionContext;
 
                 await channelContext.channel.deleteExchange(baseExchangeName);
@@ -44,7 +44,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result1 = null;
 
-                        const result2 = await instance.createExchange(baseExchangeName, 'topic');
+                        const result2 = await instance.createExchange({ name: baseExchangeName, type: 'topic' });
 
                         try {
                             await channelContext.channel.checkExchange(baseExchangeName);
@@ -68,8 +68,8 @@ describe('BunnyBus', () => {
                         let result = null;
 
                         await Promise.all([
-                            instance.createExchange(baseExchangeName, 'topic'),
-                            instance.createExchange(baseExchangeName, 'topic')
+                            instance.createExchange({ name: baseExchangeName, type: 'topic' }),
+                            instance.createExchange({ name: baseExchangeName, type: 'topic' })
                         ]);
 
                         try {
@@ -91,8 +91,8 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.createExchange(baseExchangeName, 'topic'),
-                            await instance.createExchange(baseExchangeName, 'topic');
+                        await instance.createExchange({ name: baseExchangeName, type: 'topic' });
+                        await instance.createExchange({ name: baseExchangeName, type: 'topic' });
 
                         try {
                             await channelContext.channel.checkExchange(baseExchangeName);
@@ -115,12 +115,12 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.createExchange(baseExchangeName, 'topic');
+                        await instance.createExchange({ name: baseExchangeName, type: 'topic' });
 
                         try {
                             // removing the connection cancels all channels attached to it.
                             // so we have to reinstate the channel used for this test as well
-                            await instance._autoBuildChannelContext(baseChannelName);
+                            await instance._autoBuildChannelContext({ channelName: baseChannelName });
                             await channelContext.channel.checkExchange(baseExchangeName);
                         } catch (err) {
                             result = err;
@@ -141,7 +141,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.createExchange(baseExchangeName, 'topic');
+                        await instance.createExchange({ name: baseExchangeName, type: 'topic' });
 
                         try {
                             await channelContext.channel.checkExchange(baseExchangeName);
@@ -164,7 +164,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result1 = null;
 
-                        const result2 = await instance.createExchange(baseExchangeName, 'topic');
+                        const result2 = await instance.createExchange({ name: baseExchangeName, type: 'topic' });
 
                         try {
                             await channelContext.channel.checkExchange(baseExchangeName);

--- a/test/lab/BunnyBus/createQueue.js
+++ b/test/lab/BunnyBus/createQueue.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-queue';
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 connectionContext = channelContext.connectionContext;
 
                 await channelContext.channel.deleteQueue(baseQueueName);
@@ -44,7 +44,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result1 = null;
 
-                        const result2 = await instance.createQueue(baseQueueName);
+                        const result2 = await instance.createQueue({ name: baseQueueName });
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);
@@ -68,7 +68,10 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await Promise.all([instance.createQueue(baseQueueName), instance.createQueue(baseQueueName)]);
+                        await Promise.all([
+                            instance.createQueue(baseQueueName),
+                            instance.createQueue({ name: baseQueueName })
+                        ]);
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);
@@ -89,7 +92,8 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.createQueue(baseQueueName), await instance.createQueue(baseQueueName);
+                        await instance.createQueue({ name: baseQueueName });
+                        await instance.createQueue({ name: baseQueueName });
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);
@@ -112,12 +116,12 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.createQueue(baseQueueName);
+                        await instance.createQueue({ name: baseQueueName });
 
                         try {
                             // removing the connection cancels all channels attached to it.
                             // so we have to reinstate the channel used for this test as well
-                            await instance._autoBuildChannelContext(baseChannelName);
+                            await instance._autoBuildChannelContext({ channelName: baseChannelName });
                             await channelContext.channel.checkQueue(baseQueueName);
                         } catch (err) {
                             result = err;
@@ -138,7 +142,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.createQueue(baseQueueName);
+                        await instance.createQueue({ name: baseQueueName });
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);
@@ -161,7 +165,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result1 = null;
 
-                        const result2 = await instance.createQueue(baseQueueName);
+                        const result2 = await instance.createQueue({ name: baseQueueName });
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);

--- a/test/lab/BunnyBus/deleteExchange.js
+++ b/test/lab/BunnyBus/deleteExchange.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
             const baseExchangeName = 'test-exchange';
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 connectionContext = channelContext.connectionContext;
 
                 await channelContext.channel.assertExchange(
@@ -48,7 +48,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result1 = null;
 
-                        const result2 = await instance.deleteExchange(baseExchangeName);
+                        const result2 = await instance.deleteExchange({ name: baseExchangeName });
 
                         try {
                             await channelContext.channel.checkExchange(baseExchangeName);
@@ -71,8 +71,8 @@ describe('BunnyBus', () => {
                         let result = null;
 
                         await Promise.all([
-                            instance.deleteExchange(baseExchangeName),
-                            instance.deleteExchange(baseExchangeName)
+                            instance.deleteExchange({ name: baseExchangeName }),
+                            instance.deleteExchange({ name: baseExchangeName })
                         ]);
 
                         try {
@@ -94,8 +94,8 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.deleteExchange(baseExchangeName),
-                            await instance.deleteExchange(baseExchangeName);
+                        await instance.deleteExchange({ name: baseExchangeName });
+                        await instance.deleteExchange({ name: baseExchangeName });
 
                         try {
                             await channelContext.channel.checkExchange(baseExchangeName);
@@ -118,12 +118,12 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.deleteExchange(baseExchangeName);
+                        await instance.deleteExchange({ name: baseExchangeName });
 
                         try {
                             // removing the connection cancels all channels attached to it.
                             // so we have to reinstate the channel used for this test as well
-                            await instance._autoBuildChannelContext(baseChannelName);
+                            await instance._autoBuildChannelContext({ channelName: baseChannelName });
                             await channelContext.channel.checkExchange(baseExchangeName);
                         } catch (err) {
                             result = err;
@@ -144,7 +144,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.deleteExchange(baseExchangeName);
+                        await instance.deleteExchange({ name: baseExchangeName });
 
                         try {
                             await channelContext.channel.checkExchange(baseExchangeName);

--- a/test/lab/BunnyBus/deleteQueue.js
+++ b/test/lab/BunnyBus/deleteQueue.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-queue';
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 connectionContext = channelContext.connectionContext;
 
                 await channelContext.channel.assertQueue(baseQueueName, BunnyBus.DEFAULT_QUEUE_CONFIGURATION);
@@ -44,7 +44,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result1 = null;
 
-                        const result2 = await instance.deleteQueue(baseQueueName);
+                        const result2 = await instance.deleteQueue({ name: baseQueueName });
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);
@@ -67,7 +67,10 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await Promise.all([instance.deleteQueue(baseQueueName), instance.deleteQueue(baseQueueName)]);
+                        await Promise.all([
+                            instance.deleteQueue({ name: baseQueueName }),
+                            instance.deleteQueue({ name: baseQueueName })
+                        ]);
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);
@@ -88,7 +91,8 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.deleteQueue(baseQueueName), await instance.deleteQueue(baseQueueName);
+                        await instance.deleteQueue({ name: baseQueueName });
+                        await instance.deleteQueue({ name: baseQueueName });
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);
@@ -111,12 +115,12 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.deleteQueue(baseQueueName);
+                        await instance.deleteQueue({ name: baseQueueName });
 
                         try {
                             // removing the connection cancels all channels attached to it.
                             // so we have to reinstate the channel used for this test as well
-                            await instance._autoBuildChannelContext(baseChannelName);
+                            await instance._autoBuildChannelContext({ channelName: baseChannelName });
                             await channelContext.channel.checkQueue(baseQueueName);
                         } catch (err) {
                             result = err;
@@ -137,7 +141,7 @@ describe('BunnyBus', () => {
                     async () => {
                         let result = null;
 
-                        await instance.deleteQueue(baseQueueName);
+                        await instance.deleteQueue({ name: baseQueueName });
 
                         try {
                             await channelContext.channel.checkQueue(baseQueueName);

--- a/test/lab/BunnyBus/end-to-end/auto-recovery.js
+++ b/test/lab/BunnyBus/end-to-end/auto-recovery.js
@@ -25,7 +25,7 @@ describe('BunnyBus', () => {
             connectionManager = instance.connections;
             channelManager = instance.channels;
 
-            channelContext = await instance._autoBuildChannelContext(baseChannelName);
+            channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
         });
 
         afterEach(async () => {
@@ -48,7 +48,7 @@ describe('BunnyBus', () => {
                 const handlers = {};
 
                 const consumePromise = new Promise(async (resolve) => {
-                    handlers['test-event'] = async (sentMessage, ack) => {
+                    handlers['test-event'] = async ({ message: sentMessage, ack }) => {
                         expect(sentMessage).to.contains(message);
 
                         await ack();
@@ -72,10 +72,10 @@ describe('BunnyBus', () => {
                     setTimeout(resolve, 4000);
                 });
 
-                await instance.subscribe(baseQueueName, handlers);
+                await instance.subscribe({ queue: baseQueueName, handlers });
                 await channelManager.close(targetChannelName);
                 await recoveryPromise;
-                await instance.publish(message);
+                await instance.publish({ message });
                 await consumePromise;
                 await timeDelayPromise;
             });

--- a/test/lab/BunnyBus/end-to-end/load.js
+++ b/test/lab/BunnyBus/end-to-end/load.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
                 connectionManager = instance.connections;
                 channelManager = instance.channels;
 
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -45,7 +45,7 @@ describe('BunnyBus', () => {
             });
 
             afterEach(async () => {
-                await instance.unsubscribe(baseQueueName);
+                await instance.unsubscribe({ queue: baseQueueName });
             });
 
             after(async () => {
@@ -61,11 +61,11 @@ describe('BunnyBus', () => {
             it('should publish all messages within 3 seconds', { timeout: 3000 }, async () => {
                 const promises = [];
 
-                // Do this to primse the connection
-                await instance.publish(message);
+                // Do this to prime the connection
+                await instance.publish({ message });
 
                 for (let i = 0; i < publishTarget; ++i) {
-                    promises.push(instance.publish(message));
+                    promises.push(instance.publish({ message }));
                 }
 
                 await Promise.all(promises);
@@ -77,7 +77,7 @@ describe('BunnyBus', () => {
                 const handlers = {};
 
                 const promise = new Promise(async (resolve) => {
-                    handlers['a.promise'] = async (msg, ack) => {
+                    handlers['a.promise'] = async ({ ack }) => {
                         await ack();
 
                         if (++count === publishTarget) {
@@ -86,8 +86,12 @@ describe('BunnyBus', () => {
                     };
                 });
 
-                await instance.subscribe(baseQueueName, handlers, {
-                    queue: { durable: false }
+                await instance.subscribe({
+                    queue: baseQueueName,
+                    handlers,
+                    options: {
+                        queue: { durable: false }
+                    }
                 });
 
                 await promise;
@@ -110,7 +114,7 @@ describe('BunnyBus', () => {
                 connectionManager = instance.connections;
                 channelManager = instance.channels;
 
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -127,7 +131,7 @@ describe('BunnyBus', () => {
             });
 
             afterEach(async () => {
-                await instance.unsubscribe(baseQueueName);
+                await instance.unsubscribe({ queue: baseQueueName });
             });
 
             after(async () => {
@@ -142,10 +146,10 @@ describe('BunnyBus', () => {
                 const promises = [];
 
                 // Do this to primse the connection
-                await instance.publish(message);
+                await instance.publish({ message });
 
                 for (let i = 0; i < publishTarget; ++i) {
-                    promises.push(instance.publish(message));
+                    promises.push(instance.publish({ message }));
                 }
 
                 await Promise.all(promises);
@@ -157,7 +161,7 @@ describe('BunnyBus', () => {
                 const handlers = {};
 
                 const promise = new Promise(async (resolve) => {
-                    handlers['a.promise'] = async (msg, ack) => {
+                    handlers['a.promise'] = async ({ ack }) => {
                         await ack();
 
                         if (++count === publishTarget) {
@@ -166,8 +170,12 @@ describe('BunnyBus', () => {
                     };
                 });
 
-                await instance.subscribe(baseQueueName, handlers, {
-                    queue: { durable: false }
+                await instance.subscribe({
+                    queue: baseQueueName,
+                    handlers,
+                    options: {
+                        queue: { durable: false }
+                    }
                 });
 
                 await promise;

--- a/test/lab/BunnyBus/end-to-end/prefetch-ordering.js
+++ b/test/lab/BunnyBus/end-to-end/prefetch-ordering.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
                 connectionManager = instance.connections;
                 channelManager = instance.channels;
 
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -45,7 +45,7 @@ describe('BunnyBus', () => {
             });
 
             afterEach(async () => {
-                await instance.unsubscribe(baseQueueName);
+                await instance.unsubscribe({ queue: baseQueueName });
             });
 
             after(async () => {
@@ -67,11 +67,11 @@ describe('BunnyBus', () => {
                     const handlers = {};
 
                     for (let i = 0; i < publishTarget; ++i) {
-                        await instance.publish(Object.assign({}, message, { number: i }));
+                        await instance.publish({ message: Object.assign({}, message, { number: i }) });
                     }
 
                     const promise = new Promise(async (resolve, reject) => {
-                        handlers[pattern] = async (msg, ack) => {
+                        handlers[pattern] = async ({ message: msg, ack }) => {
                             const waitTimeInMs = randomNumber();
                             await new Promise((handlerResolve) => setTimeout(handlerResolve, waitTimeInMs));
 
@@ -87,8 +87,12 @@ describe('BunnyBus', () => {
                         };
                     });
 
-                    await instance.subscribe(baseQueueName, handlers, {
-                        queue: { durable: false }
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers,
+                        options: {
+                            queue: { durable: false }
+                        }
                     });
 
                     await promise;

--- a/test/lab/BunnyBus/events/messageAcked.js
+++ b/test/lab/BunnyBus/events/messageAcked.js
@@ -26,7 +26,7 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-events-message-acked-queue';
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -55,7 +55,7 @@ describe('BunnyBus', () => {
                 const message = { event: routeKey, foo: 'bar' };
                 const transactionId = 'foo-567-xyz';
                 const handlers = {};
-                handlers[routeKey] = async (consumedMessage, ack, reject, requeue) => await ack();
+                handlers[routeKey] = async ({ ack }) => await ack();
 
                 const promise = new Promise((resolve) => {
                     const eventHandler = (sentOptions, sentMessage) => {
@@ -76,8 +76,8 @@ describe('BunnyBus', () => {
                     instance.on(BunnyBus.MESSAGE_ACKED_EVENT, eventHandler);
                 });
 
-                await instance.subscribe(baseQueueName, handlers);
-                await instance.publish(message, { transactionId });
+                await instance.subscribe({ queue: baseQueueName, handlers });
+                await instance.publish({ message, options: { transactionId } });
                 await promise;
             });
         });

--- a/test/lab/BunnyBus/events/messageDispatched.js
+++ b/test/lab/BunnyBus/events/messageDispatched.js
@@ -26,7 +26,7 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-events-message-dispatched-queue';
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -55,7 +55,7 @@ describe('BunnyBus', () => {
                 const message = { event: routeKey, foo: 'bar' };
                 const transactionId = 'foo-123-xyz';
                 const handlers = {};
-                handlers[routeKey] = async (consumedMessage, ack, reject, requeue) => await ack();
+                handlers[routeKey] = async ({ ack }) => await ack();
 
                 const promise = new Promise((resolve) => {
                     const eventHandler = (sentOptions, sentMessage) => {
@@ -75,8 +75,8 @@ describe('BunnyBus', () => {
                     instance.on(BunnyBus.MESSAGE_DISPATCHED_EVENT, eventHandler);
                 });
 
-                await instance.subscribe(baseQueueName, handlers);
-                await instance.publish(message, { transactionId });
+                await instance.subscribe({ queue: baseQueueName, handlers });
+                await instance.publish({ message, options: { transactionId } });
                 await promise;
             });
         });

--- a/test/lab/BunnyBus/events/messageRejected.js
+++ b/test/lab/BunnyBus/events/messageRejected.js
@@ -27,7 +27,7 @@ describe('BunnyBus', () => {
             const baseErrorQueueName = `${baseQueueName}_error`;
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -59,8 +59,7 @@ describe('BunnyBus', () => {
                 const message = { event: routeKey, foo: 'bar' };
                 const transactionId = 'foo-567-xyz';
                 const handlers = {};
-                handlers[routeKey] = async (consumedMessage, ack, reject, requeue) =>
-                    await reject({ reason: rejectionReason });
+                handlers[routeKey] = async ({ rej }) => await rej({ reason: rejectionReason });
 
                 const promise = new Promise((resolve) => {
                     const eventHandler = (sentOptions, sentMessage) => {
@@ -82,8 +81,8 @@ describe('BunnyBus', () => {
                     instance.on(BunnyBus.MESSAGE_REJECTED_EVENT, eventHandler);
                 });
 
-                await instance.subscribe(baseQueueName, handlers);
-                await instance.publish(message, { transactionId });
+                await instance.subscribe({ queue: baseQueueName, handlers });
+                await instance.publish({ message, options: { transactionId } });
                 await promise;
             });
         });

--- a/test/lab/BunnyBus/events/messageRequeued.js
+++ b/test/lab/BunnyBus/events/messageRequeued.js
@@ -26,7 +26,7 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-events-message-requeued-queue';
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -55,7 +55,7 @@ describe('BunnyBus', () => {
                 const message = { event: routeKey, foo: 'bar' };
                 const transactionId = 'foo-789-xyz';
                 const handlers = {};
-                handlers[routeKey] = async (consumedMessage, ack, reject, requeue) => await requeue();
+                handlers[routeKey] = async ({ requeue }) => await requeue();
 
                 const promise = new Promise((resolve) => {
                     const eventHandler = (sentOptions, sentMessage) => {
@@ -77,8 +77,8 @@ describe('BunnyBus', () => {
                     instance.on(BunnyBus.MESSAGE_REQUEUED_EVENT, eventHandler);
                 });
 
-                await instance.subscribe(baseQueueName, handlers);
-                await instance.publish(message, { transactionId });
+                await instance.subscribe({ queue: baseQueueName, handlers });
+                await instance.publish({ message, options: { transactionId } });
                 await promise;
             });
         });

--- a/test/lab/BunnyBus/events/publish.js
+++ b/test/lab/BunnyBus/events/publish.js
@@ -27,7 +27,7 @@ describe('BunnyBus', () => {
             const message = { event: 'published-event', name: 'bunnybus' };
 
             after(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await channelContext.channel.deleteExchange(instance.config.globalExchange);
 
@@ -47,7 +47,7 @@ describe('BunnyBus', () => {
                         resolve();
                     });
 
-                    await instance.publish(message);
+                    await instance.publish({ message });
                 });
             });
         });

--- a/test/lab/BunnyBus/events/recovery.js
+++ b/test/lab/BunnyBus/events/recovery.js
@@ -29,11 +29,11 @@ describe('BunnyBus', () => {
             beforeEach(async () => {
                 instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
 
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
             });
 
             after(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 await channelContext.channel.deleteQueue(baseQueueName);
 
                 await instance.stop();
@@ -107,8 +107,11 @@ describe('BunnyBus', () => {
 
             it('should emit RECOVERY_FAILED_EVENT when recovery process fails', { timeout: 6000 }, async () => {
                 // Setup a subscripton so recovery is necessary.
-                await instance.subscribe(baseQueueName, {
-                    'subscribed-event': () => {}
+                await instance.subscribe({
+                    queue: baseQueueName,
+                    handlers: {
+                        'subscribed-event': () => {}
+                    }
                 });
 
                 // Make sure connection/channel state is in a good place.

--- a/test/lab/BunnyBus/events/subscribe.js
+++ b/test/lab/BunnyBus/events/subscribe.js
@@ -26,7 +26,7 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-events-subscribe-queue';
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
             });
 
             after(async () => {
@@ -47,7 +47,7 @@ describe('BunnyBus', () => {
 
             it('should emit SUBSCRIBED_EVENT when consume handlers are setup', async () => {
                 const handlers = {};
-                handlers['subscribed-event'] = (consumedMessage, ack, reject, requeue) => {};
+                handlers['subscribed-event'] = () => {};
 
                 await new Promise(async (resolve) => {
                     instance.once(BunnyBus.SUBSCRIBED_EVENT, (queue) => {
@@ -55,7 +55,7 @@ describe('BunnyBus', () => {
                         resolve();
                     });
 
-                    await instance.subscribe(baseQueueName, handlers);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
                 });
             });
         });

--- a/test/lab/BunnyBus/events/unsubscribe.js
+++ b/test/lab/BunnyBus/events/unsubscribe.js
@@ -26,14 +26,14 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-events-unsubscribe-queue';
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
             });
 
             beforeEach(async () => {
                 const handlers = {};
                 handlers['subscribed-event'] = (consumedMessage, ack, reject, requeue) => {};
 
-                await instance.subscribe(baseQueueName, handlers);
+                await instance.subscribe({ queue: baseQueueName, handlers });
             });
 
             after(async () => {
@@ -53,7 +53,7 @@ describe('BunnyBus', () => {
                         resolve();
                     });
 
-                    await instance.unsubscribe(baseQueueName);
+                    await instance.unsubscribe({ queue: baseQueueName });
                 });
             });
         });

--- a/test/lab/BunnyBus/get.js
+++ b/test/lab/BunnyBus/get.js
@@ -37,7 +37,7 @@ describe('BunnyBus', () => {
             };
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await channelContext.channel.assertQueue(baseQueueName, BunnyBus.DEFAULT_QUEUE_CONFIGURATION);
                 await channelContext.channel.purgeQueue(baseQueueName);

--- a/test/lab/BunnyBus/getAll.js
+++ b/test/lab/BunnyBus/getAll.js
@@ -28,14 +28,14 @@ describe('BunnyBus', () => {
             const message = { name: 'bunnybus' };
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await channelContext.channel.assertQueue(baseQueueName, BunnyBus.DEFAULT_QUEUE_CONFIGURATION);
                 await channelContext.channel.purgeQueue(baseQueueName);
             });
 
             after(async () => {
-                await instance._autoBuildChannelContext(baseChannelName);
+                await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 await channelContext.channel.deleteQueue(baseQueueName);
                 await instance.stop();
             });

--- a/test/lab/BunnyBus/getAll.js
+++ b/test/lab/BunnyBus/getAll.js
@@ -40,12 +40,8 @@ describe('BunnyBus', () => {
                 await instance.stop();
             });
 
-            it('should retrieve all message without meta flag', async () => {
-                await Assertions.assertGetAll(instance, channelContext, null, null, message, baseQueueName, false, 10);
-            });
-
-            it('should retrieve all message with meta flag', async () => {
-                await Assertions.assertGetAll(instance, channelContext, null, null, message, baseQueueName, true, 10);
+            it('should retrieve all message', async () => {
+                await Assertions.assertGetAll(instance, channelContext, null, null, message, baseQueueName, 10);
             });
 
             it('should not error when connection does not pre-exist', async () => {
@@ -56,7 +52,6 @@ describe('BunnyBus', () => {
                     null,
                     message,
                     baseQueueName,
-                    true,
                     10
                 );
             });
@@ -69,7 +64,6 @@ describe('BunnyBus', () => {
                     channelManager,
                     message,
                     baseQueueName,
-                    true,
                     10
                 );
             });

--- a/test/lab/BunnyBus/publish.js
+++ b/test/lab/BunnyBus/publish.js
@@ -29,12 +29,12 @@ describe('BunnyBus', () => {
 
             beforeEach(async () => {
                 instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 await channelContext.channel.assertQueue(baseQueueName);
             });
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.assertQueue(baseQueueName, BunnyBus.DEFAULT_QUEUE_CONFIGURATION),

--- a/test/lab/BunnyBus/purgeQueue.js
+++ b/test/lab/BunnyBus/purgeQueue.js
@@ -28,7 +28,7 @@ describe('BunnyBus', () => {
             const baseQueueName = 'test-queue';
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
                 connectionContext = channelContext.connectionContext;
 
                 await channelContext.channel.assertQueue(baseQueueName, BunnyBus.DEFAULT_QUEUE_CONFIGURATION);
@@ -45,7 +45,7 @@ describe('BunnyBus', () => {
             it(`should purge a queue with name ${baseQueueName}`, async () => {
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        expect(await instance.purgeQueue(baseQueueName)).to.be.true();
+                        expect(await instance.purgeQueue({ name: baseQueueName })).to.be.true();
                         await expect(channelContext.channel.checkQueue(baseQueueName)).to.not.reject();
                     },
                     connectionContext,
@@ -59,7 +59,7 @@ describe('BunnyBus', () => {
 
                 await Assertions.autoRecoverChannel(
                     async () => {
-                        expect(await instance.purgeQueue(baseQueueName)).to.be.false();
+                        expect(await instance.purgeQueue({ name: baseQueueName })).to.be.false();
                     },
                     connectionContext,
                     channelContext,

--- a/test/lab/BunnyBus/resubscribe-unsubscribe/single-queue.js
+++ b/test/lab/BunnyBus/resubscribe-unsubscribe/single-queue.js
@@ -21,14 +21,11 @@ describe('BunnyBus', () => {
             const baseChannelName = 'bunnybus-resubscribe';
             const baseQueueName = 'test-resubscribe-queue';
             const baseErrorQueueName = `${baseQueueName}_error`;
-            const publishOptions = { routeKey: 'a.b' };
-            const subscribeOptionsWithMeta = { meta: true };
             const messageObject = { event: 'a.b', name: 'bunnybus' };
             const messageString = 'bunnybus';
-            const messageBuffer = Buffer.from(messageString);
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -38,7 +35,7 @@ describe('BunnyBus', () => {
             });
 
             afterEach(async () => {
-                await instance.unsubscribe(baseQueueName);
+                await instance.unsubscribe({ queue: baseQueueName });
             });
 
             after(async () => {
@@ -53,32 +50,38 @@ describe('BunnyBus', () => {
 
             it('should consume message (Object) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
-                    await instance.subscribe(baseQueueName, {
-                        [messageObject.event]: async (consumedMessage, ack) => {
-                            expect(consumedMessage).to.be.equal(messageObject);
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers: {
+                            [messageObject.event]: async ({ message: consumedMessage, ack }) => {
+                                expect(consumedMessage).to.be.equal(messageObject);
 
-                            await ack();
-                            resolve();
+                                await ack();
+                                resolve();
+                            }
                         }
-                    }),
-                        await instance.unsubscribe(baseQueueName);
-                    await instance.resubscribe(baseQueueName);
-                    await instance.publish(messageObject);
+                    });
+                    await instance.unsubscribe({ queue: baseQueueName });
+                    await instance.resubscribe({ queue: baseQueueName });
+                    await instance.publish({ message: messageObject });
                 });
             });
 
             it('should not reject when handler subscription exist', async () => {
                 return new Promise(async (resolve) => {
-                    await instance.subscribe(baseQueueName, {
-                        [messageObject.event]: async (consumedMessage, ack) => {
-                            expect(consumedMessage).to.be.equal(messageObject);
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers: {
+                            [messageObject.event]: async ({ message: consumedMessage, ack }) => {
+                                expect(consumedMessage).to.be.equal(messageObject);
 
-                            await ack();
-                            resolve();
+                                await ack();
+                                resolve();
+                            }
                         }
-                    }),
-                        await expect(instance.resubscribe(baseQueueName)).to.not.reject();
-                    await instance.publish(messageObject);
+                    });
+                    await expect(instance.resubscribe({ queue: baseQueueName })).to.not.reject();
+                    await instance.publish({ message: messageObject });
                 });
             });
         });

--- a/test/lab/BunnyBus/send.js
+++ b/test/lab/BunnyBus/send.js
@@ -29,13 +29,13 @@ describe('BunnyBus', () => {
             const messageWithEvent = { event: 'event1', name: 'bunnybus' };
 
             beforeEach(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await channelContext.channel.deleteQueue(baseQueueName);
             });
 
             after(async () => {
-                instance._autoBuildChannelContext(baseChannelName);
+                instance._autoBuildChannelContext({ channelName: baseChannelName });
                 await channelContext.channel.deleteQueue(baseQueueName);
 
                 await instance.stop();

--- a/test/lab/BunnyBus/stop.js
+++ b/test/lab/BunnyBus/stop.js
@@ -24,7 +24,7 @@ describe('BunnyBus', () => {
             const baseQueueName2 = 'test-stop-queue2';
 
             after(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteQueue(baseQueueName1),
@@ -35,8 +35,8 @@ describe('BunnyBus', () => {
             });
 
             it('should destroy all connections, channels and subscriptions', async () => {
-                await instance.subscribe(baseQueueName1, { a: (...args) => {} });
-                await instance.subscribe(baseQueueName2, { b: (...args) => {} });
+                await instance.subscribe({ queue: baseQueueName1, handlers: { a: (...args) => {} } });
+                await instance.subscribe({ queue: baseQueueName2, handlers: { b: (...args) => {} } });
 
                 expect(instance.connections.list()).to.be.length(1);
                 expect(instance.channels.list()).to.be.length(3);

--- a/test/lab/BunnyBus/subscribe-unsubscribe/connection-channel-failures.js
+++ b/test/lab/BunnyBus/subscribe-unsubscribe/connection-channel-failures.js
@@ -22,7 +22,7 @@ describe('BunnyBus', () => {
     });
 
     describe('public methods', () => {
-        describe('negative tests', () => {
+        describe('connection and channel failure tests', () => {
             const baseChannelName = 'bunnybus-negative-tests';
             const baseQueueName = 'test-negative-tests-queue';
             const baseErrorQueueName = `${baseQueueName}_error`;
@@ -30,7 +30,7 @@ describe('BunnyBus', () => {
             const handlers = { event1: () => {} };
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -40,14 +40,14 @@ describe('BunnyBus', () => {
             });
 
             afterEach(async () => {
-                await instance.unsubscribe(baseQueueName);
+                await instance.unsubscribe({ queue: baseQueueName });
 
                 instance.subscriptions._subscriptions.clear();
                 instance.subscriptions._blockQueues.clear();
             });
 
             after(async () => {
-                await instance._autoBuildChannelContext(baseChannelName);
+                await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -65,7 +65,7 @@ describe('BunnyBus', () => {
                 instance.subscriptions.tag(baseQueueName, consumerTag);
 
                 try {
-                    await instance.subscribe(baseQueueName, handlers);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
                 } catch (err) {
                     result = err;
                 }
@@ -79,7 +79,7 @@ describe('BunnyBus', () => {
                 instance.subscriptions.block(baseQueueName);
 
                 try {
-                    await instance.subscribe(baseQueueName, handlers);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
                 } catch (err) {
                     result = err;
                 }
@@ -90,13 +90,13 @@ describe('BunnyBus', () => {
             it('should not error when connection does not pre-exist', async () => {
                 await connectionManager.close(BunnyBus.DEFAULT_CONNECTION_NAME);
 
-                await instance.subscribe(baseQueueName, handlers);
+                await instance.subscribe({ queue: baseQueueName, handlers });
             });
 
             it('should not error when channel does not pre-exist', async () => {
                 await channelManager.close(BunnyBus.QUEUE_CHANNEL_NAME(baseQueueName));
 
-                await instance.subscribe(baseQueueName, handlers);
+                await instance.subscribe({ queue: baseQueueName, handlers });
             });
         });
     });

--- a/test/lab/BunnyBus/subscribe-unsubscribe/multiple-queues.js
+++ b/test/lab/BunnyBus/subscribe-unsubscribe/multiple-queues.js
@@ -24,7 +24,7 @@ describe('BunnyBus', () => {
             const message = { event: 'a.b', name: 'bunnybus' };
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -34,7 +34,10 @@ describe('BunnyBus', () => {
             });
 
             afterEach(async () => {
-                await Promise.all([instance.unsubscribe(baseQueueName1), instance.unsubscribe(baseQueueName2)]);
+                await Promise.all([
+                    instance.unsubscribe({ queue: baseQueueName1 }),
+                    instance.unsubscribe({ queue: baseQueueName2 })
+                ]);
             });
 
             after(async () => {
@@ -52,7 +55,7 @@ describe('BunnyBus', () => {
                     const handlers = {};
                     let counter = 0;
 
-                    handlers[message.event] = async (consumedMessage, ack) => {
+                    handlers[message.event] = async ({ message: consumedMessage, ack }) => {
                         expect(consumedMessage.name).to.be.equal(message.name);
                         await ack();
 
@@ -62,11 +65,11 @@ describe('BunnyBus', () => {
                     };
 
                     await Promise.all([
-                        instance.subscribe(baseQueueName1, handlers),
-                        instance.subscribe(baseQueueName2, handlers)
+                        instance.subscribe({ queue: baseQueueName1, handlers }),
+                        instance.subscribe({ queue: baseQueueName2, handlers })
                     ]);
 
-                    await instance.publish(message);
+                    await instance.publish({ message });
                 });
             });
         });

--- a/test/lab/BunnyBus/subscribe-unsubscribe/single-queue-with-#-route.js
+++ b/test/lab/BunnyBus/subscribe-unsubscribe/single-queue-with-#-route.js
@@ -25,7 +25,7 @@ describe('BunnyBus', () => {
             const routableObject = { event: 'abc.hello.world.xyz', name: 'bunnybus' };
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -51,15 +51,15 @@ describe('BunnyBus', () => {
             it('should consume message (Object) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[subscriptionKey] = async (consumedMessage, ack) => {
+                    handlers[subscriptionKey] = async ({ message: consumedMessage, ack }) => {
                         expect(consumedMessage).to.be.equal(routableObject);
 
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(routableObject);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: routableObject });
                 });
             });
         });

--- a/test/lab/BunnyBus/subscribe-unsubscribe/single-queue-with-*-route.js
+++ b/test/lab/BunnyBus/subscribe-unsubscribe/single-queue-with-*-route.js
@@ -25,7 +25,7 @@ describe('BunnyBus', () => {
             const routableObject = { event: 'abc.helloworld.xyz', name: 'bunnybus' };
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
@@ -51,15 +51,15 @@ describe('BunnyBus', () => {
             it('should consume message (Object) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[subscriptionKey] = async (consumedMessage, ack) => {
+                    handlers[subscriptionKey] = async ({ message: consumedMessage, ack }) => {
                         expect(consumedMessage).to.be.equal(routableObject);
 
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(routableObject);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: routableObject });
                 });
             });
         });

--- a/test/lab/BunnyBus/subscribe-unsubscribe/single-queue.js
+++ b/test/lab/BunnyBus/subscribe-unsubscribe/single-queue.js
@@ -23,7 +23,6 @@ describe('BunnyBus', () => {
             const baseErrorQueueName = `${baseQueueName}_error`;
             const customErrorQueueName = `${baseQueueName}_custom_error`;
             const publishOptions = { routeKey: 'a.b' };
-            const subscribeOptionsWithMeta = { meta: true };
             const messageObject = { event: 'a.b', name: 'bunnybus' };
             const messageString = 'bunnybus';
             const messageBuffer = Buffer.from(messageString);
@@ -57,31 +56,15 @@ describe('BunnyBus', () => {
             it('should consume message (Object) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[messageObject.event] = async ({ message: consumedMessage, ack }) => {
+                    handlers[messageObject.event] = async ({ message: consumedMessage, metaData, ack }) => {
                         expect(consumedMessage).to.be.equal(messageObject);
+                        expect(metaData.headers).to.exist();
 
                         await ack();
                         resolve();
                     };
 
                     await instance.subscribe({ queue: baseQueueName, handlers });
-                    await instance.publish({ message: messageObject });
-                });
-            });
-
-            it('should consume message (Object) and meta from queue and acknowledge off', async () => {
-                return new Promise(async (resolve) => {
-                    const handlers = {};
-                    handlers[messageObject.event] = async ({ message: consumedMessage, metaData: meta, ack }) => {
-                        expect(consumedMessage).to.equal(messageObject);
-                        expect(meta).to.not.be.a.function();
-                        expect(meta.headers).to.exist();
-
-                        await ack();
-                        resolve();
-                    };
-
-                    await instance.subscribe({ queue: baseQueueName, handlers, options: subscribeOptionsWithMeta });
                     await instance.publish({ message: messageObject });
                 });
             });
@@ -89,31 +72,15 @@ describe('BunnyBus', () => {
             it('should consume message (String) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, ack }) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, metaData, ack }) => {
                         expect(consumedMessage).to.be.equal(messageString);
+                        expect(metaData.headers).to.exist();
 
                         await ack();
                         resolve();
                     };
 
                     await instance.subscribe({ queue: baseQueueName, handlers });
-                    await instance.publish({ message: messageString, options: publishOptions });
-                });
-            });
-
-            it('should consume message (String) and meta from queue and acknowledge off', async () => {
-                return new Promise(async (resolve) => {
-                    const handlers = {};
-                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, metaData: meta, ack }) => {
-                        expect(consumedMessage).to.equal(messageString);
-                        expect(meta).to.not.be.a.function();
-                        expect(meta.headers).to.exist();
-
-                        await ack();
-                        resolve();
-                    };
-
-                    await instance.subscribe({ queue: baseQueueName, handlers, options: subscribeOptionsWithMeta });
                     await instance.publish({ message: messageString, options: publishOptions });
                 });
             });
@@ -121,31 +88,15 @@ describe('BunnyBus', () => {
             it('should consume message (Buffer) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, ack }) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, metaData, ack }) => {
                         expect(consumedMessage).to.be.equal(messageBuffer);
+                        expect(metaData.headers).to.exist();
 
                         await ack();
                         resolve();
                     };
 
                     await instance.subscribe({ queue: baseQueueName, handlers });
-                    await instance.publish({ message: messageBuffer, options: publishOptions });
-                });
-            });
-
-            it('should consume message (Buffer) and meta from queue and acknowledge off', async () => {
-                return new Promise(async (resolve) => {
-                    const handlers = {};
-                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, metaData: meta, ack }) => {
-                        expect(consumedMessage).to.equal(messageBuffer);
-                        expect(meta).to.not.be.a.function();
-                        expect(meta.headers).to.exist();
-
-                        await ack();
-                        resolve();
-                    };
-
-                    await instance.subscribe({ queue: baseQueueName, handlers, options: subscribeOptionsWithMeta });
                     await instance.publish({ message: messageBuffer, options: publishOptions });
                 });
             });

--- a/test/lab/BunnyBus/subscribe-unsubscribe/single-queue.js
+++ b/test/lab/BunnyBus/subscribe-unsubscribe/single-queue.js
@@ -21,7 +21,7 @@ describe('BunnyBus', () => {
             const baseChannelName = 'bunnybus-subscribe';
             const baseQueueName = 'test-subscribe-queue';
             const baseErrorQueueName = `${baseQueueName}_error`;
-            const customErrroQueueName = `${baseQueueName}_custom_error`;
+            const customErrorQueueName = `${baseQueueName}_custom_error`;
             const publishOptions = { routeKey: 'a.b' };
             const subscribeOptionsWithMeta = { meta: true };
             const messageObject = { event: 'a.b', name: 'bunnybus' };
@@ -29,18 +29,18 @@ describe('BunnyBus', () => {
             const messageBuffer = Buffer.from(messageString);
 
             before(async () => {
-                channelContext = await instance._autoBuildChannelContext(baseChannelName);
+                channelContext = await instance._autoBuildChannelContext({ channelName: baseChannelName });
 
                 await Promise.all([
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
                     channelContext.channel.deleteQueue(baseQueueName),
                     channelContext.channel.deleteQueue(baseErrorQueueName),
-                    channelContext.channel.deleteQueue(customErrroQueueName)
+                    channelContext.channel.deleteQueue(customErrorQueueName)
                 ]);
             });
 
             afterEach(async () => {
-                await instance.unsubscribe(baseQueueName);
+                await instance.unsubscribe({ queue: baseQueueName });
             });
 
             after(async () => {
@@ -48,7 +48,7 @@ describe('BunnyBus', () => {
                     channelContext.channel.deleteExchange(instance.config.globalExchange),
                     channelContext.channel.deleteQueue(baseQueueName),
                     channelContext.channel.deleteQueue(baseErrorQueueName),
-                    channelContext.channel.deleteQueue(customErrroQueueName)
+                    channelContext.channel.deleteQueue(customErrorQueueName)
                 ]);
 
                 await instance.stop();
@@ -57,21 +57,22 @@ describe('BunnyBus', () => {
             it('should consume message (Object) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[messageObject.event] = async (consumedMessage, ack) => {
+                    handlers[messageObject.event] = async ({ message: consumedMessage, ack }) => {
                         expect(consumedMessage).to.be.equal(messageObject);
 
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers), await instance.publish(messageObject);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: messageObject });
                 });
             });
 
             it('should consume message (Object) and meta from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[messageObject.event] = async (consumedMessage, meta, ack) => {
+                    handlers[messageObject.event] = async ({ message: consumedMessage, metaData: meta, ack }) => {
                         expect(consumedMessage).to.equal(messageObject);
                         expect(meta).to.not.be.a.function();
                         expect(meta.headers).to.exist();
@@ -80,30 +81,30 @@ describe('BunnyBus', () => {
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, subscribeOptionsWithMeta);
-                    await instance.publish(messageObject);
+                    await instance.subscribe({ queue: baseQueueName, handlers, options: subscribeOptionsWithMeta });
+                    await instance.publish({ message: messageObject });
                 });
             });
 
             it('should consume message (String) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, ack }) => {
                         expect(consumedMessage).to.be.equal(messageString);
 
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(messageString, publishOptions);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: messageString, options: publishOptions });
                 });
             });
 
             it('should consume message (String) and meta from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[publishOptions.routeKey] = async (consumedMessage, meta, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, metaData: meta, ack }) => {
                         expect(consumedMessage).to.equal(messageString);
                         expect(meta).to.not.be.a.function();
                         expect(meta.headers).to.exist();
@@ -112,30 +113,30 @@ describe('BunnyBus', () => {
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, subscribeOptionsWithMeta);
-                    await instance.publish(messageString, publishOptions);
+                    await instance.subscribe({ queue: baseQueueName, handlers, options: subscribeOptionsWithMeta });
+                    await instance.publish({ message: messageString, options: publishOptions });
                 });
             });
 
             it('should consume message (Buffer) from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, ack }) => {
                         expect(consumedMessage).to.be.equal(messageBuffer);
 
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(messageBuffer, publishOptions);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: messageBuffer, options: publishOptions });
                 });
             });
 
             it('should consume message (Buffer) and meta from queue and acknowledge off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[publishOptions.routeKey] = async (consumedMessage, meta, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, metaData: meta, ack }) => {
                         expect(consumedMessage).to.equal(messageBuffer);
                         expect(meta).to.not.be.a.function();
                         expect(meta.headers).to.exist();
@@ -144,19 +145,19 @@ describe('BunnyBus', () => {
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, subscribeOptionsWithMeta);
-                    await instance.publish(messageBuffer, publishOptions);
+                    await instance.subscribe({ queue: baseQueueName, handlers, options: subscribeOptionsWithMeta });
+                    await instance.publish({ message: messageBuffer, options: publishOptions });
                 });
             });
 
             it('should consume message (Object) from queue and reject off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[messageObject.event] = async (consumedMessage, ack, reject) => {
+                    handlers[messageObject.event] = async ({ message: consumedMessage, ack, rej }) => {
                         expect(consumedMessage).to.be.equal(messageObject);
 
-                        await reject();
-                        const payload = await instance.get(baseErrorQueueName);
+                        await rej();
+                        const payload = await instance.get({ queue: baseErrorQueueName });
 
                         expect(payload).to.exist();
                         const errorMessage = JSON.parse(payload.content.toString());
@@ -166,19 +167,19 @@ describe('BunnyBus', () => {
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(messageObject);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: messageObject });
                 });
             });
 
             it('should consume message (Buffer) from queue and reject off', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack, reject) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, rej }) => {
                         expect(consumedMessage).to.be.equal(messageBuffer);
 
-                        await reject();
-                        const payload = await instance.get(baseErrorQueueName);
+                        await rej();
+                        const payload = await instance.get({ queue: baseErrorQueueName });
 
                         expect(payload).to.exist();
                         const errorMessage = payload.content;
@@ -188,27 +189,27 @@ describe('BunnyBus', () => {
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(messageBuffer, publishOptions);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: messageBuffer, options: publishOptions });
                 });
             });
 
             it('should consume message (Object) from queue and reject off to a custom specified error queue', async () => {
                 return new Promise(async (resolve) => {
                     const handlers = {};
-                    handlers[messageObject.event] = async (consumedMessage, ack, reject) => {
+                    handlers[messageObject.event] = async ({ message: consumedMessage, rej }) => {
                         expect(consumedMessage).to.be.equal(messageObject);
 
-                        await reject({ errorQueue: customErrroQueueName });
-                        const payload = await instance.get(customErrroQueueName);
+                        await rej({ errorQueue: customErrorQueueName });
+                        const payload = await instance.get({ queue: customErrorQueueName });
 
                         expect(payload).to.exist();
 
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(messageObject);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: messageObject });
                 });
             });
 
@@ -217,7 +218,7 @@ describe('BunnyBus', () => {
                     const handlers = {};
                     const maxRetryCount = 3;
                     let retryCount = 0;
-                    handlers[messageObject.event] = async (consumedMessage, ack, reject, requeue) => {
+                    handlers[messageObject.event] = async ({ message: consumedMessage, ack, requeue }) => {
                         ++retryCount;
 
                         if (retryCount < maxRetryCount) {
@@ -231,8 +232,8 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, { maxRetryCount });
-                    await instance.publish(messageObject);
+                    await instance.subscribe({ queue: baseQueueName, handlers, options: { maxRetryCount } });
+                    await instance.publish({ message: messageObject });
                 });
             });
 
@@ -241,7 +242,7 @@ describe('BunnyBus', () => {
                 const maxRetryCount = 1;
                 const transactionId = 'retry-abc-134';
 
-                handlers[messageObject.event] = async (consumedMessage, ack, reject, requeue) => await requeue();
+                handlers[messageObject.event] = async ({ requeue }) => await requeue();
 
                 const promise = new Promise((resolve) => {
                     instance.once(BunnyBus.MESSAGE_REJECTED_EVENT, (sentOptions, sentPayload) => {
@@ -252,8 +253,8 @@ describe('BunnyBus', () => {
                     });
                 });
 
-                await instance.subscribe(baseQueueName, handlers, { maxRetryCount });
-                await instance.publish(messageObject, { transactionId });
+                await instance.subscribe({ queue: baseQueueName, handlers, options: { maxRetryCount } });
+                await instance.publish({ message: messageObject, options: { transactionId } });
                 await promise;
             });
 
@@ -262,7 +263,7 @@ describe('BunnyBus', () => {
                     const handlers = {};
                     const maxRetryCount = 3;
                     let retryCount = 0;
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack, reject, requeue) => {
+                    handlers[publishOptions.routeKey] = async ({ message: consumedMessage, ack, requeue }) => {
                         ++retryCount;
 
                         if (retryCount < maxRetryCount) {
@@ -275,8 +276,8 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, { maxRetryCount });
-                    await instance.publish(messageBuffer, publishOptions);
+                    await instance.subscribe({ queue: baseQueueName, handlers, options: { maxRetryCount } });
+                    await instance.publish({ message: messageBuffer, options: publishOptions });
                 });
             });
 
@@ -293,7 +294,7 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ ack }) => {
                         //this should never be called.
                         await ack();
                         reject(new Error('not expected to be called'));
@@ -305,8 +306,12 @@ describe('BunnyBus', () => {
                         resolve();
                     });
 
-                    await instance.subscribe(baseQueueName, handlers, {
-                        validatePublisher: true
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers,
+                        options: {
+                            validatePublisher: true
+                        }
                     });
                     await channelContext.channel.publish(
                         config.globalExchange,
@@ -330,13 +335,17 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ ack }) => {
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, {
-                        validatePublisher: false
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers,
+                        options: {
+                            validatePublisher: false
+                        }
                     });
                     await channelContext.channel.publish(
                         config.globalExchange,
@@ -362,14 +371,18 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ ack }) => {
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, {
-                        validatePublisher: true,
-                        validateVersion: false
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers,
+                        options: {
+                            validatePublisher: true,
+                            validateVersion: false
+                        }
                     });
                     await channelContext.channel.publish(
                         config.globalExchange,
@@ -395,7 +408,7 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ ack }) => {
                         //this should never be called.
                         await ack();
                         reject(new Error('not expected to be called'));
@@ -407,9 +420,13 @@ describe('BunnyBus', () => {
                         resolve();
                     });
 
-                    await instance.subscribe(baseQueueName, handlers, {
-                        validatePublisher: true,
-                        validateVersion: true
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers,
+                        options: {
+                            validatePublisher: true,
+                            validateVersion: true
+                        }
                     });
                     await channelContext.channel.publish(
                         config.globalExchange,
@@ -434,14 +451,18 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack, reject, requeue) => {
+                    handlers[publishOptions.routeKey] = async ({ ack }) => {
                         //this should never be called.
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, {
-                        validatePublisher
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers,
+                        options: {
+                            validatePublisher
+                        }
                     });
                     await channelContext.channel.publish(
                         config.globalExchange,
@@ -468,14 +489,18 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack, reject, requeue) => {
+                    handlers[publishOptions.routeKey] = async ({ ack }) => {
                         //this should never be called.
                         await ack();
                         resolve();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers, {
-                        validateVersion
+                    await instance.subscribe({
+                        queue: baseQueueName,
+                        handlers,
+                        options: {
+                            validateVersion
+                        }
                     });
                     await channelContext.channel.publish(
                         config.globalExchange,
@@ -489,15 +514,19 @@ describe('BunnyBus', () => {
             it('should not create exchange to queue binding when disableQueueBind == true', async () => {
                 const handlers = {};
 
-                handlers[messageObject.event] = async (consumedMessage, ack) => {
+                handlers[messageObject.event] = async ({ ack }) => {
                     await ack();
                 };
 
-                await instance.subscribe(baseQueueName, handlers, {
-                    disableQueueBind: true
+                await instance.subscribe({
+                    queue: baseQueueName,
+                    handlers,
+                    options: {
+                        disableQueueBind: true
+                    }
                 });
-                await instance.publish(messageObject);
-                const result = await instance.get(baseQueueName);
+                await instance.publish({ message: messageObject });
+                const result = await instance.get({ queue: baseQueueName });
 
                 expect(result).to.be.false();
             });
@@ -508,7 +537,7 @@ describe('BunnyBus', () => {
                 const rejectionReason = `message consumed with no matching routeKey (${unregisteredTopic}) handler`;
 
                 const handlers = {};
-                handlers[messageObject.event] = async (consumedMessage, ack) => await ack();
+                handlers[messageObject.event] = async ({ ack }) => await ack();
 
                 const promise = new Promise(async (resolve) => {
                     const eventHandler = (sentOptions, sentMessage) => {
@@ -530,15 +559,19 @@ describe('BunnyBus', () => {
                     instance.on(BunnyBus.MESSAGE_REJECTED_EVENT, eventHandler);
                 });
 
-                await instance.subscribe(baseQueueName, handlers, {
-                    rejectUnroutedMessages: true
+                await instance.subscribe({
+                    queue: baseQueueName,
+                    handlers,
+                    options: {
+                        rejectUnroutedMessages: true
+                    }
                 }),
                     await channelContext.channel.bindQueue(
                         baseQueueName,
                         instance.config.globalExchange,
                         unregisteredTopic
                     );
-                await instance.publish(testObject);
+                await instance.publish({ message: testObject });
                 await promise;
             });
 
@@ -554,18 +587,18 @@ describe('BunnyBus', () => {
                         }
                     };
 
-                    handlers[publishOptions.routeKey] = async (consumedMessage, ack) => {
+                    handlers[publishOptions.routeKey] = async ({ ack }) => {
                         ack();
                         resolver();
                     };
 
-                    handlers['a.#'] = async (consumedMessage, ack) => {
+                    handlers['a.#'] = async ({ ack }) => {
                         ack();
                         resolver();
                     };
 
-                    await instance.subscribe(baseQueueName, handlers);
-                    await instance.publish(messageString, publishOptions);
+                    await instance.subscribe({ queue: baseQueueName, handlers });
+                    await instance.publish({ message: messageString, options: publishOptions });
                 });
 
                 await new Promise((resolve) => setTimeout(resolve, 500));

--- a/test/lab/assertions/assertGet.js
+++ b/test/lab/assertions/assertGet.js
@@ -17,7 +17,7 @@ const assertGet = async (instance, channelContext, connectionManager, channelMan
         await channelManager.close(BunnyBus.QUEUE_CHANNEL_NAME(queueName));
     }
 
-    const result = await instance.get(queueName);
+    const result = await instance.get({ queue: queueName });
 
     expect(result.content.toString()).to.equal(buffer.toString());
 };

--- a/test/lab/assertions/assertGetAll.js
+++ b/test/lab/assertions/assertGetAll.js
@@ -5,33 +5,14 @@ const BunnyBus = require('../../../lib');
 
 const expect = Code.expect;
 
-const assertGetAll = async (
-    instance,
-    channelContext,
-    connectionManager,
-    channelManager,
-    message,
-    queueName,
-    meta,
-    limit
-) => {
+const assertGetAll = async (instance, channelContext, connectionManager, channelManager, message, queueName, limit) => {
     const buffer = Buffer.from(JSON.stringify(message));
 
     let handleCounter = 0;
 
-    const options = {
-        meta
-    };
+    const options = {};
 
-    const handlerWithoutMeta = async ({ message: sentMessage, ack }) => {
-        ++handleCounter;
-
-        expect(sentMessage).to.be.equal(message);
-
-        await ack();
-    };
-
-    const handlerWithMeta = async ({ message: sentMessage, metaData: sentMeta, ack }) => {
+    const handler = async ({ message: sentMessage, metaData: sentMeta, ack }) => {
         ++handleCounter;
 
         expect(sentMessage).to.be.equal(message);
@@ -39,8 +20,6 @@ const assertGetAll = async (
 
         await ack();
     };
-
-    const handler = meta ? handlerWithMeta : handlerWithoutMeta;
 
     for (let i = 0; i < limit; ++i) {
         await channelContext.channel.sendToQueue(queueName, buffer);

--- a/test/lab/assertions/assertGetAll.js
+++ b/test/lab/assertions/assertGetAll.js
@@ -23,7 +23,7 @@ const assertGetAll = async (
         meta
     };
 
-    const handlerWithoutMeta = async (sentMessage, ack) => {
+    const handlerWithoutMeta = async ({ message: sentMessage, ack }) => {
         ++handleCounter;
 
         expect(sentMessage).to.be.equal(message);
@@ -31,7 +31,7 @@ const assertGetAll = async (
         await ack();
     };
 
-    const handlerWithMeta = async (sentMessage, sentMeta, ack) => {
+    const handlerWithMeta = async ({ message: sentMessage, metaData: sentMeta, ack }) => {
         ++handleCounter;
 
         expect(sentMessage).to.be.equal(message);
@@ -56,7 +56,7 @@ const assertGetAll = async (
         await channelManager.close(BunnyBus.QUEUE_CHANNEL_NAME(queueName));
     }
 
-    await instance.getAll(queueName, handler, options);
+    await instance.getAll({ queue: queueName, handler, options });
 
     expect(handleCounter).to.equal(limit);
 };

--- a/test/lab/assertions/assertPublish.js
+++ b/test/lab/assertions/assertPublish.js
@@ -27,10 +27,10 @@ const assertPublish = async (
         Object.assign(options, miscOptions);
     }
 
-    await instance.publish(message, options);
+    await instance.publish({ message, options });
 
     if (!channelContext.channel) {
-        await instance._autoBuildChannelContext(channelContext.name);
+        await instance._autoBuildChannelContext({ channelName: channelContext.name });
     }
 
     const payload = await channelContext.channel.get(queueName);

--- a/test/lab/assertions/assertSend.js
+++ b/test/lab/assertions/assertSend.js
@@ -24,10 +24,10 @@ const assertSend = async (
         Object.assign(options, miscOptions);
     }
 
-    await instance.send(message, queueName, options);
+    await instance.send({ message, queue: queueName, options });
 
     if (!channelContext.channel) {
-        await instance._autoBuildChannelContext(channelContext.name);
+        await instance._autoBuildChannelContext({ channelName: channelContext.name });
     }
 
     const result = await channelContext.channel.get(queueName);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change introduces new public interfaces that are styled for name based parameterization.  

As an example:

```
// Old syntax
await bunnyBus.publish('hello world');
// New syntax
await bunnyBus.publish({ message: 'hello world' })
```

```
// Old syntax
await bunnyBus.subscribe({
    'queue1',
    { 'topicA': async (msg, meta, ack, rej, requeue) => {} },
    { meta: true }
});
// New syntax
await bunnyBus.subscribe({
    queue: 'queue1',
    handlers: { 'topicA': async ({ message, metaData, ack, rej, requeue }) => {} }
    options: {}
});
```

## Related Issue

* [epsagon-node-frameworks PR42](https://github.com/epsagon/epsagon-node-frameworks/pull/42)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As we are integrating with potential providers for distributed tracing services.  Some providers like Epsagon are willing to extend BunnyBus to allow for proper instrumentation with `AsyncContextHook` not behaving properly when messages have to funnel through an ordering queue.  So `amqplib` proxy intercepts won't work.  The `subscribe` interface needs to be designed to be proxy-able so that information like route keys are accessible.  Pre v7 implementation only had route keys accessible through the `subscribe` method when `options.meta===true` was passed in.  But most common use case does not enable `meta` since most consumers have no need for raw message header data.  We want a subscribe method that allows for pass through of `meta` information with no optionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.